### PR TITLE
Fix/removes pdf logo

### DIFF
--- a/src/modules/shared/pages/innovation/innovation-record.component.html
+++ b/src/modules/shared/pages/innovation/innovation-record.component.html
@@ -43,8 +43,12 @@
     </ng-container>
 
     <h2>All sections</h2>
-
-    <a [href]="documentUrl">
+    <ng-container *ngIf="module === 'innovator'">
+      <a [href]="documentUrl">
+        <h3 class="nhsuk-u-margin-bottom-6">Download all questions (DOCX, 820KB)</h3>
+      </a>
+    </ng-container>
+    <a [href]="pdfDocumentUrl">
       <p class="nhsuk-heading-m nhsuk-u-margin-bottom-1">Export your innovation record to PDF</p>
     </a>
     <p class="nhsuk-u-margin-bottom-6">

--- a/src/modules/shared/pages/innovation/innovation-record.component.ts
+++ b/src/modules/shared/pages/innovation/innovation-record.component.ts
@@ -16,6 +16,7 @@ export class PageInnovationRecordComponent extends CoreComponent implements OnIn
   module: '' | 'innovator' | 'accessor' | 'assessment' = '';
   baseUrl = '';
   documentUrl = '';
+  pdfDocumentUrl = '';
 
   alert: AlertType = { type: null };
 
@@ -57,8 +58,8 @@ export class PageInnovationRecordComponent extends CoreComponent implements OnIn
 
     this.module = this.activatedRoute.snapshot.data.module;
     this.baseUrl = `/${this.module}/innovations/${this.activatedRoute.snapshot.params.innovationId}/record/sections`;
-    // this.documentUrl = `${this.stores.environment.APP_ASSETS_URL}/NHS-innovation-service-record.docx`;
-    this.documentUrl = `${this.stores.environment.APP_URL}/exports/${this.activatedRoute.snapshot.params.innovationId}/pdf`;
+    this.documentUrl = `${this.stores.environment.APP_ASSETS_URL}/NHS-innovation-service-record.docx`;
+    this.pdfDocumentUrl = `${this.stores.environment.APP_URL}/exports/${this.activatedRoute.snapshot.params.innovationId}/pdf`;
     this.innovationId = this.activatedRoute.snapshot.params.innovationId;
     this.innovationName = '';
 

--- a/src/server/utils/pdf/parser.ts
+++ b/src/server/utils/pdf/parser.ts
@@ -48,8 +48,10 @@ export const generatePDF = async (innovationId: string, userId: string, config: 
     throw new PDFGeneratorParserError(error);
   }
 
-  generator
-    .addLogo();
+  // temporarely disables logo
+
+  // generator
+  //   .addLogo();
 
   generator
     .hero(innovation.name)


### PR DESCRIPTION
- Temporarely removes the NHS Logo from the PDF Generator until path issues are fixed.
- Re-adds `Download all Questions (DOCX)` link when the viewer is the Innovator
- Removes `Download all Questions (DOCX)` link when the viewer is NOT the Innovator (Accessors and Needs Assessment users cannot see the link)
