### PR TITLE
Changed conditions for organisation choice page

### DIFF
--- a/src/modules/feature-modules/accessor/pages/innovation/support/support-update.component.html
+++ b/src/modules/feature-modules/accessor/pages/innovation/support/support-update.component.html
@@ -78,7 +78,7 @@
 
               <div id="suggestOrganisations-hint" class="nhsuk-hint">
                 <div>
-                  <a href="transactional/accessor/innovations/{{innovationId}}/support/organisations" target="_blank" rel="noopener noreferrer">Review innovation's support status here (open in a new window)</a>
+                  <a href="/transactional/accessor/innovations/{{innovationId}}/support/organisations" target="_blank" rel="noopener noreferrer">Review innovation's support status here (open in a new window)</a>
                 </div>
                 {{ formfieldSuggestOrganisations.description }}
               </div>

--- a/src/modules/feature-modules/accessor/pages/innovation/support/support-update.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovation/support/support-update.component.ts
@@ -199,9 +199,9 @@ export class InnovationSupportUpdateComponent extends CoreComponent implements O
     this.accessorService.saveSupportStatus(this.innovationId, body, this.supportId).subscribe(() => {
 
       // this.setAlertSuccess('Support status updated and organisation suggestions sent', { message: 'The Innovation Support status has been successfully updated and the Innovator has been notified of your accompanying suggestions and feedback.' });
-      this.setAlertSuccess('Support status updated', { message: 'The innovation support status has been successfully updated.' });
 
       if (this.chosenStatus && this.currentStatus === InnovationSupportStatusEnum.ENGAGING && [InnovationSupportStatusEnum.COMPLETE, InnovationSupportStatusEnum.NOT_YET, InnovationSupportStatusEnum.UNSUITABLE].includes(this.chosenStatus)) {
+        this.setAlertSuccess('Support status updated', { message: 'The innovation support status has been successfully updated.' });
         this.setPageTitle('Suggest other organisations', { showPage: false });
         this.stepNumber = 4;
       } else {

--- a/src/modules/feature-modules/accessor/pages/innovation/support/support-update.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovation/support/support-update.component.ts
@@ -201,10 +201,11 @@ export class InnovationSupportUpdateComponent extends CoreComponent implements O
       // this.setAlertSuccess('Support status updated and organisation suggestions sent', { message: 'The Innovation Support status has been successfully updated and the Innovator has been notified of your accompanying suggestions and feedback.' });
       this.setAlertSuccess('Support status updated', { message: 'The innovation support status has been successfully updated.' });
 
-      if (this.chosenStatus && [InnovationSupportStatusEnum.COMPLETE, InnovationSupportStatusEnum.NOT_YET, InnovationSupportStatusEnum.UNSUITABLE].includes(this.chosenStatus)) {
+      if (this.chosenStatus && this.currentStatus === InnovationSupportStatusEnum.ENGAGING && [InnovationSupportStatusEnum.COMPLETE, InnovationSupportStatusEnum.NOT_YET, InnovationSupportStatusEnum.UNSUITABLE].includes(this.chosenStatus)) {
         this.setPageTitle('Suggest other organisations', { showPage: false });
         this.stepNumber = 4;
       } else {
+        this.setRedirectAlertSuccess('Support status updated', { message: 'The innovation support status has been successfully updated.' });
         this.redirectTo(`/accessor/innovations/${this.innovationId}/support`);
       }
 


### PR DESCRIPTION
- Organisation choice page only appears on status update from Engaging to Not yet, Unsuitable, Completed
- Fixed link to list of support status of all organisations on organisation choice page