### PR TITLE
bug fix on innovations list of unit to be inactivated

### DIFF
--- a/src/modules/feature-modules/admin/wizards/organisation-unit-inactivate/steps/innovations-step.component.ts
+++ b/src/modules/feature-modules/admin/wizards/organisation-unit-inactivate/steps/innovations-step.component.ts
@@ -67,8 +67,12 @@ export class WizardOrganisationUnitInactivateInnovationsStepComponent extends Co
     this.organisationsService.getOrganisationUnitInnovationsList(this.data.organisation.id, this.data.organisationUnit.id, this.tableList.getAPIQueryParams()).subscribe(
       response => {
         this.innovationStatusCounters = response.innovationsByStatus.filter(i => [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED].includes(i.status));
-        let tableData = response.innovationsList.filter(i => [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED].includes(i.status));
-        this.tableList.setData(tableData, this.innovationStatusCounters.map(i => i.count).reduce((a,b) => a+b));
+        this.tableList.setData(
+          response.innovationsList
+           .filter(i => [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED].includes(i.status)),
+          this.innovationStatusCounters
+           .map(i => i.count).reduce((a,b) => a+b)
+        );
         this.setPageStatus('READY');
       },
       () => {

--- a/src/modules/feature-modules/admin/wizards/organisation-unit-inactivate/steps/innovations-step.component.ts
+++ b/src/modules/feature-modules/admin/wizards/organisation-unit-inactivate/steps/innovations-step.component.ts
@@ -7,6 +7,7 @@ import { TableModel } from '@app/base/models';
 import { WizardStepComponentType, WizardStepEventType } from '@app/base/types';
 
 import { GetOrganisationUnitInnovationsListDTO, OrganisationsService } from '@modules/feature-modules/admin/services/organisations.service';
+import { InnovationSupportStatusEnum } from '@modules/stores/innovation';
 
 import { InnovationsStepInputType, InnovationsStepOutputType } from './innovations-step.types';
 
@@ -65,8 +66,9 @@ export class WizardOrganisationUnitInactivateInnovationsStepComponent extends Co
 
     this.organisationsService.getOrganisationUnitInnovationsList(this.data.organisation.id, this.data.organisationUnit.id, this.tableList.getAPIQueryParams()).subscribe(
       response => {
-        this.innovationStatusCounters = response.innovationsByStatus;
-        this.tableList.setData(response.innovationsList, response.count);
+        this.innovationStatusCounters = response.innovationsByStatus.filter(i => [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED].includes(i.status));
+        let tableData = response.innovationsList.filter(i => [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED].includes(i.status));
+        this.tableList.setData(tableData, this.innovationStatusCounters.map(i => i.count).reduce((a,b) => a+b));
         this.setPageStatus('READY');
       },
       () => {


### PR DESCRIPTION
Temporary bug fix (still using legacy endpoint) to only display "Engaging" and "Further info" innovations of a unit being inactivated by admin user