### PR TITLE
Feature/119192 actions from section flows

### DIFF
--- a/src/modules/feature-modules/innovator/innovator-routing.module.ts
+++ b/src/modules/feature-modules/innovator/innovator-routing.module.ts
@@ -58,6 +58,7 @@ import { PageExportRecordInfoComponent } from '@modules/shared/pages/innovation/
 import { PageInnovationDataSharingAndSupportComponent } from '@modules/shared/pages/innovation/data-sharing-and-support/data-sharing-and-support.component';
 import { PageInnovationAssessmentOverviewComponent } from '@modules/shared/pages/innovation/assessment/assessment-overview.component';
 import { PageInnovationActionTrackerListComponent } from '@modules/shared/pages/innovation/actions/action-tracker-list.component';
+import { PageInnovationActionSectionInfoComponent } from '@modules/shared/pages/innovation/actions/action-section-info.component';
 // // Notifications.
 import { PageNotificationsListComponent } from '@modules/shared/pages/notifications/notifications-list.component';
 // // Terms of use.
@@ -254,6 +255,16 @@ const routes: Routes = [
                               }
 
                             ]
+                          },
+
+                          {
+                            path: 'actions',
+                            pathMatch: 'full',
+                            component: PageInnovationActionSectionInfoComponent,
+                            data: {
+                              breadcrumb: null,
+                              layout: { type: 'full' }
+                            }
                           }
 
                         ]
@@ -290,8 +301,8 @@ const routes: Routes = [
                     },
                     children: [
                       {
-                        path: '', pathMatch: 'full', component: InnovationActionTrackerInfoComponent,
-                        data: { breadcrumb: null }
+                        path: '', pathMatch: 'full', component: PageInnovationActionSectionInfoComponent,
+                        data: { breadcrumb: null, layout: { type: 'full' } }
                       },
                       {
                         path: 'decline', pathMatch: 'full', component: InnovationActionTrackerDeclineComponent,

--- a/src/modules/feature-modules/innovator/innovator-routing.module.ts
+++ b/src/modules/feature-modules/innovator/innovator-routing.module.ts
@@ -306,7 +306,7 @@ const routes: Routes = [
                       },
                       {
                         path: 'decline', pathMatch: 'full', component: InnovationActionTrackerDeclineComponent,
-                        data: { breadcrumb: 'Decline' }
+                        data: { breadcrumb: null, layout: { type: 'full' } }
                       }
                     ]
                   }

--- a/src/modules/feature-modules/innovator/pages/innovation/action-tracker/action-tracker-decline.component.html
+++ b/src/modules/feature-modules/innovator/pages/innovation/action-tracker/action-tracker-decline.component.html
@@ -4,8 +4,8 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <form [formGroup]="form">
-        <theme-form-textarea controlName="message" label="Enter a message" description="Please describe why you're declining this action" [pageUniqueField]="false" lengthLimit="medium"></theme-form-textarea>
-        <button class="nhsuk-button nhsuk-u-margin-top-3 nhsuk-u-margin-right-3" (click)="onSubmit()">Confirm</button>
+        <theme-form-textarea controlName="message" description="Please describe the reason why you're declining this action" [pageUniqueField]="false" lengthLimit="medium"></theme-form-textarea>
+        <button class="nhsuk-button nhsuk-u-margin-top-3" (click)="onSubmit()">Decline action</button>
       </form>
 
       <div>

--- a/src/modules/feature-modules/innovator/pages/innovation/action-tracker/action-tracker-decline.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation/action-tracker/action-tracker-decline.component.ts
@@ -21,7 +21,7 @@ export class InnovationActionTrackerDeclineComponent extends CoreComponent imple
   actionDisplayId: string = '';
 
   form = new FormGroup({
-    message: new FormControl<string>('', { validators: CustomValidators.required('Please choose a status') })
+    message: new FormControl<string>('', { validators: CustomValidators.required('Please enter a reason') })
   }, { updateOn: 'blur' });
 
 
@@ -44,7 +44,8 @@ export class InnovationActionTrackerDeclineComponent extends CoreComponent imple
 
       this.actionDisplayId = response.displayId;
 
-      this.setPageTitle(response.name, { hint: response.displayId });
+      this.setPageTitle(`Decline action: ${response.name.toLowerCase()}`, { size: 'l' });
+
       this.setPageStatus('READY');
 
     });
@@ -64,12 +65,9 @@ export class InnovationActionTrackerDeclineComponent extends CoreComponent imple
       message: this.form.value.message ?? ''
     }
 
-    this.innovationsService.updateAction(this.innovationId, this.actionId, body).subscribe({
-      next: response => {
-        this.setRedirectAlertSuccess('The action was declined', { message: 'The accessor will be notified' });
-        this.redirectTo(`/innovator/innovations/${this.innovationId}/action-tracker/${response.id}`);
-      },
-      error: () => this.setAlertUnknownError()
+    this.innovationsService.updateAction(this.innovationId, this.actionId, body).subscribe((response) => {
+      this.setRedirectAlertSuccess('You have declined this requested action', { message: 'The accessor will be notified' });
+      this.redirectTo(`/innovator/innovations/${this.innovationId}/action-tracker/${response.id}`);
     });
 
   }

--- a/src/modules/shared/pages/innovation/actions/action-section-info.component.html
+++ b/src/modules/shared/pages/innovation/actions/action-section-info.component.html
@@ -24,7 +24,7 @@
         </div>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key nhsuk-u-padding-3">Requested by</dt>
-          <dd class="nhsuk-summary-list__value nhsuk-u-padding-3">{{ action.createdBy }}</dd>
+          <dd class="nhsuk-summary-list__value nhsuk-u-padding-3">{{ action.createdBy.name }}, {{ action.createdBy.organisationUnit }}</dd>
         </div>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key nhsuk-u-padding-3">Section</dt>
@@ -106,8 +106,8 @@
       <div class="nhsuk-card x-card-top-border">
         <div class="nhsuk-card__content">
           <h2 class="nhsuk-card__heading nhsuk-heading-m">If you have any questions</h2>
-          <a routerLink="/accessor/innovations/{{ innovationId }}/threads">
-            Go to messages and start a new conversation with your supporting organisations
+          <a routerLink="/innovator/innovations/{{ innovationId }}/threads">
+            Go to messages and start a new conversation with your supporting organisations.
           </a>
         </div>
       </div>

--- a/src/modules/shared/pages/innovation/actions/action-section-info.component.html
+++ b/src/modules/shared/pages/innovation/actions/action-section-info.component.html
@@ -1,0 +1,119 @@
+<theme-content-wrapper [status]="pageStatus">
+
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds" *ngIf="action">
+
+      <h3>{{ action.name }}</h3>
+
+      <dl class="nhsuk-summary-list">
+        <div class="nhsuk-summary-list__row">
+          <dt class="nhsuk-summary-list__key nhsuk-u-padding-3">Status</dt>
+          <dd class="nhsuk-summary-list__value nhsuk-u-padding-3">
+            <theme-tag
+              type="{{ 'shared.catalog.innovation.action_status.' + action.status + '.cssColorClass' | translate }}"
+              label="{{ 'shared.catalog.innovation.action_status.' + action.status + '.name' | translate }}"></theme-tag>
+            <a routerLink="/{{ stores.authentication.userUrlBasePath() }}/innovations/{{ innovationId }}/action-tracker/statuses"
+              class="float-r" arial-label="View actions status keys information"> What does this mean? </a>
+          </dd>
+        </div>
+        <div class="nhsuk-summary-list__row">
+          <dt class="nhsuk-summary-list__key nhsuk-u-padding-3">Requested on</dt>
+          <dd class="nhsuk-summary-list__value nhsuk-u-padding-3">
+            {{ action.createdAt | date: ('app.date_formats.long_date' | translate) }}
+          </dd>
+        </div>
+        <div class="nhsuk-summary-list__row">
+          <dt class="nhsuk-summary-list__key nhsuk-u-padding-3">Requested by</dt>
+          <dd class="nhsuk-summary-list__value nhsuk-u-padding-3">{{ action.createdBy }}</dd>
+        </div>
+        <div class="nhsuk-summary-list__row">
+          <dt class="nhsuk-summary-list__key nhsuk-u-padding-3">Section</dt>
+          <dd class="nhsuk-summary-list__value nhsuk-u-padding-3">{{ stores.innovation.getSectionNumber(action.section) }}: {{
+            stores.innovation.getSectionTitle(action.section) }}</dd>
+        </div>
+        <div class="nhsuk-summary-list__row">
+          <dt class="nhsuk-summary-list__key nhsuk-u-padding-3">Description</dt>
+          <dd class="nhsuk-summary-list__value nhsuk-u-padding-3 textarea-info-section">{{ action.description }}</dd>
+        </div>
+      </dl>
+
+
+      <ng-container *ngIf="stores.authentication.isAccessorType()">
+
+        <a routerLink="/accessor/innovations/{{ innovationId }}/record/sections/{{ action.section }}"
+          class="nhsuk-button nhsuk-u-margin-right-3"> Review section </a>
+        <a *ngIf="action.status === 'IN_REVIEW'"
+          routerLink="/accessor/innovations/{{ innovationId }}/action-tracker/{{ action.id }}/edit"
+          class="nhsuk-button nhsuk-button--secondary">
+          Update status
+        </a>
+
+      </ng-container>
+
+      <ng-container *ngIf="stores.authentication.isInnovatorType()">
+
+        <a routerLink="/innovator/innovations/{{ innovationId }}/record/sections/{{ action.section }}"
+          class="nhsuk-button nhsuk-u-margin-right-3"> Go to section </a>
+        <a *ngIf="action.status === 'REQUESTED'"
+          routerLink="/innovator/innovations/{{ innovationId }}/action-tracker/{{ action.id }}/decline"
+          class="nhsuk-button nhsuk-button--secondary">
+          Decline action
+        </a>
+
+      </ng-container>
+
+      <ng-container *ngIf="sectionId && actionsIds.length > 1">
+
+        <nav class="nhsuk-pagination nhsuk-u-margin-top-3" role="navigation" aria-label="Pagination">
+          <ul class="nhsuk-list nhsuk-pagination__list">
+            <li class="nhsuk-pagination-item--previous" *ngIf="actionNumber > 0">
+              <a class="nhsuk-pagination__link nhsuk-pagination__link--prev cursor-pointer"
+                (click)="handlePagination('previous')">
+                <span class="nhsuk-pagination__title">Previous</span>
+                <span class="nhsuk-u-visually-hidden">:</span>
+                <span class="nhsuk-pagination__page">Requested action</span>
+                <svg class="nhsuk-icon nhsuk-icon__arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                  aria-hidden="true" width="34" height="34">
+                  <path
+                    d="M4.1 12.3l2.7 3c.2.2.5.2.7 0 .1-.1.1-.2.1-.3v-2h11c.6 0 1-.4 1-1s-.4-1-1-1h-11V9c0-.2-.1-.4-.3-.5h-.2c-.1 0-.3.1-.4.2l-2.7 3c0 .2 0 .4.1.6z">
+                  </path>
+                </svg>
+              </a>
+            </li>
+            <li class="nhsuk-pagination-item--next" *ngIf="actionNumber < actionsIds.length - 1">
+              <a class="nhsuk-pagination__link nhsuk-pagination__link--next cursor-pointer"
+                (click)="handlePagination('next')">
+                <span class="nhsuk-pagination__title">Next</span>
+                <span class="nhsuk-u-visually-hidden">:</span>
+                <span class="nhsuk-pagination__page">Requested action</span>
+                <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                  aria-hidden="true" width="34" height="34">
+                  <path
+                    d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z">
+                  </path>
+                </svg>
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </ng-container>
+
+
+    </div>
+
+    <div class="nhsuk-grid-column-one-third">
+
+      <div class="nhsuk-card x-card-top-border">
+        <div class="nhsuk-card__content">
+          <h2 class="nhsuk-card__heading nhsuk-heading-m">If you have any questions</h2>
+          <a routerLink="/accessor/innovations/{{ innovationId }}/threads">
+            Go to messages and start a new conversation with your supporting organisations
+          </a>
+        </div>
+      </div>
+
+    </div>
+
+  </div>
+
+</theme-content-wrapper>

--- a/src/modules/shared/pages/innovation/actions/action-section-info.component.spec.ts
+++ b/src/modules/shared/pages/innovation/actions/action-section-info.component.spec.ts
@@ -1,0 +1,51 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { Injector } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+import { AppInjector, CoreModule } from '@modules/core';
+import { StoresModule } from '@modules/stores';
+
+import { InnovationsService } from '@modules/shared/services/innovations.service';
+import { SharedModule } from '@modules/shared/shared.module';
+import { PageInnovationActionSectionInfoComponent } from './action-section-info.component';
+
+
+describe('Shared/Pages/Innovation/PageInnovationActionSectionInfoComponent', () => {
+
+  let activatedRoute: ActivatedRoute;
+
+  let innovationsService: InnovationsService;
+
+  let component: PageInnovationActionSectionInfoComponent;
+  let fixture: ComponentFixture<PageInnovationActionSectionInfoComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        CoreModule,
+        StoresModule,
+        SharedModule
+      ]
+    });
+
+    AppInjector.setInjector(TestBed.inject(Injector));
+
+    activatedRoute = TestBed.inject(ActivatedRoute);
+
+    innovationsService = TestBed.inject(InnovationsService);
+
+  });
+
+
+  it('should create the component', () => {
+    fixture = TestBed.createComponent(PageInnovationActionSectionInfoComponent);
+    component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+
+});

--- a/src/modules/shared/pages/innovation/actions/action-section-info.component.ts
+++ b/src/modules/shared/pages/innovation/actions/action-section-info.component.ts
@@ -1,0 +1,116 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+import { CoreComponent } from '@app/base';
+import { InnovationActionInfoDTO } from '@modules/shared/services/innovations.dtos';
+import { InnovationsService } from '@modules/shared/services/innovations.service';
+
+import { NotificationContextTypeEnum } from '@modules/stores/context/context.enums';
+import { InnovationSectionEnum } from '@modules/stores/innovation';
+
+
+@Component({
+  selector: 'shared-pages-innovation-action-section-info',
+  templateUrl: './action-section-info.component.html'
+})
+export class PageInnovationActionSectionInfoComponent extends CoreComponent implements OnInit {
+
+  innovationId: string;
+  sectionId: InnovationSectionEnum;
+  actionId: string;
+
+  action?: InnovationActionInfoDTO;
+
+  actionsIds: string[] = [];
+
+  actionNumber: number = 0;
+
+  constructor(
+    private activatedRoute: ActivatedRoute,
+    private innovationsService: InnovationsService
+  ) {
+
+    super();
+
+    this.innovationId = this.activatedRoute.snapshot.params.innovationId;
+    this.sectionId = this.activatedRoute.snapshot.params.sectionId;
+    this.actionId = this.activatedRoute.snapshot.params.actionId;
+
+  }
+
+
+  ngOnInit(): void {
+
+    if (this.sectionId) {
+
+      this.innovationsService.getSectionInfo(this.innovationId, this.sectionId, { fields: ['actions'] }).subscribe(sectionInfo => {
+
+        this.actionsIds = sectionInfo.actionsIds ?? [];
+
+        if (this.actionsIds.length === 0) {
+          this.redirectTo(`${this.userUrlBasePath}/innovations/${this.innovationId}/action-tracker`);
+        }
+
+        this.actionNumber = 0;
+
+        this.getActionInfo();
+
+      });
+
+      this.setBackLink('Go back', `${this.stores.authentication.userUrlBasePath()}/innovations/${this.innovationId}/record`);
+
+    } else if (this.actionId) {
+
+      this.getActionInfo();
+
+      this.setBackLink('Go back', `${this.stores.authentication.userUrlBasePath()}/innovations/${this.innovationId}/action-tracker`);
+
+    }
+
+  }
+
+  handlePagination(action: 'previous' | 'next') {
+
+    switch (action) {
+      case 'previous':
+        if (this.actionNumber === 0) { return; }
+        this.actionNumber--;
+        break;
+      case 'next':
+        if (this.actionNumber === this.actionsIds.length - 1) { return; }
+        this.actionNumber++;
+        break;
+      default:
+    }
+
+    this.getActionInfo();
+
+  }
+
+  private getActionInfo() {
+
+    this.setPageStatus('LOADING');
+
+    if(this.sectionId) {
+      this.actionId = this.actionsIds[this.actionNumber];
+    }
+
+    this.innovationsService.getActionInfo(this.innovationId, this.actionId).subscribe(response => {
+
+      this.action = response;
+
+      if (this.actionsIds.length > 1) {
+        this.setPageTitle('Requested action', { hint: `${this.actionNumber + 1} of ${this.actionsIds.length}` });
+      } else {
+        this.setPageTitle('Requested action', { hint: this.action.displayId });
+      }
+
+      this.stores.context.dismissNotification(this.innovationId, { contextTypes: [NotificationContextTypeEnum.ACTION], contextIds: [this.actionId] });
+
+      this.setPageStatus('READY');
+
+    });
+
+  }
+
+}

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.html
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.html
@@ -169,6 +169,8 @@
                 <ng-container *ngSwitchCase="'innovator'">
                   <span *ngIf="section.openActionsCount >= 1" class="float-r">
                     <theme-tag
+                      routerLink="{{ baseUrl }}/{{section.id}}/actions"
+                      class="cursor-pointer"
                       type="{{ 'shared.catalog.innovation.action_status.REQUESTED.cssColorClass' | translate }}"
                       label="{{ section.openActionsCount + ' ' + ('dictionary.action' | pluralTranslate: section.openActionsCount | translate) + ' ' + ('shared.catalog.innovation.action_status.REQUESTED.name' | translate | lowercase) }}">
                     </theme-tag>

--- a/src/modules/shared/services/innovations.dtos.ts
+++ b/src/modules/shared/services/innovations.dtos.ts
@@ -145,7 +145,7 @@ export type InnovationActionInfoDTO = {
   name: string,
   description: string,
   createdAt: DateISOType,
-  createdBy: string;
+  createdBy: { name: string, organisationUnit: string };
 };
 
 

--- a/src/modules/shared/services/innovations.service.ts
+++ b/src/modules/shared/services/innovations.service.ts
@@ -15,6 +15,7 @@ import { InnovationStatisticsEnum } from './statistics.enum';
 import { ActivityLogTypesEnum, InnovationActionStatusEnum, InnovationExportRequestStatusEnum, InnovationGroupedStatusEnum, InnovationSectionEnum, InnovationStatusEnum, InnovationSupportStatusEnum } from '@modules/stores/innovation/innovation.enums';
 import { mainCategoryItems } from '@modules/stores/innovation/sections/catalogs.config';
 import { InnovationActionInfoDTO, InnovationActionsListDTO, InnovationActionsListInDTO, InnovationActivityLogListDTO, InnovationActivityLogListInDTO, InnovationInfoDTO, InnovationNeedsAssessmentInfoDTO, InnovationsListDTO, InnovationStatisticsDTO, InnovationSubmissionDTO, InnovationSupportInfoDTO, InnovationSupportsListDTO, InnovationSupportsLog, InnovationSupportsLogDTO, SupportLogType } from './innovations.dtos';
+import { InnovationSectionInfoDTO } from '@modules/stores/innovation/innovation.models';
 
 export enum AssessmentSupportFilterEnum {
   UNASSIGNED = 'UNASSIGNED',
@@ -377,7 +378,7 @@ export class InnovationsService extends CoreService {
         id: response.id,
         displayId: response.displayId,
         status: response.status,
-        name: `Submit '${this.stores.innovation.getSectionTitle(response.section).toLowerCase()}'`,
+        name: `Update '${this.stores.innovation.getSectionTitle(response.section).toLowerCase()}'`,
         description: response.description,
         section: response.section,
         createdAt: response.createdAt,
@@ -567,5 +568,21 @@ export class InnovationsService extends CoreService {
     const url = new UrlModel(this.API_INNOVATIONS_URL).addPath('v1/:innovationId/export-requests/:requestId/status').setPathParams({ innovationId, requestId });
     return this.http.patch<{ id: string }>(url.buildUrl(), body).pipe(take(1), map(response => response));
 
+  }
+
+  // Sections
+  getSectionInfo(innovationId: string, sectionId: string, filters: { fields?: ('actions')[]}): Observable<InnovationSectionInfoDTO> {
+
+    const qp = {
+      ...(filters.fields ? { fields: filters.fields } : {})
+    };
+
+    const url = new UrlModel(this.API_INNOVATIONS_URL).addPath('v1/:innovationId/sections/:sectionId')
+      .setPathParams({
+        innovationId,
+        sectionId
+      }).setQueryParams(qp);
+    return this.http.get<InnovationSectionInfoDTO>(url.buildUrl()).pipe(take(1), map(response => response));
+    
   }
 }

--- a/src/modules/shared/shared.module.ts
+++ b/src/modules/shared/shared.module.ts
@@ -40,6 +40,7 @@ import { PageInnovationActionTrackerListComponent } from './pages/innovation/act
 import { PageInnovationActionTrackerInfoComponent } from './pages/innovation/actions/action-tracker-info.component';
 import { PageInnovationDataSharingAndSupportComponent } from './pages/innovation/data-sharing-and-support/data-sharing-and-support.component';
 import { PageInnovationAssessmentOverviewComponent } from './pages/innovation/assessment/assessment-overview.component';
+import { PageInnovationActionSectionInfoComponent } from './pages/innovation/actions/action-section-info.component';
 // // Notifications.
 import { PageNotificationsListComponent } from './pages/notifications/notifications-list.component';
 // // Terms of use.
@@ -111,6 +112,7 @@ import { StatisticsService } from './services/statistics.service';
     PageInnovationsAdvancedReviewComponent,
     PageInnovationActionTrackerListComponent,
     PageInnovationActionTrackerInfoComponent,
+    PageInnovationActionSectionInfoComponent,
     PageInnovationDataSharingAndSupportComponent,
     PageInnovationAssessmentOverviewComponent,
     // // Notifications.

--- a/src/modules/stores/innovation/innovation.models.ts
+++ b/src/modules/stores/innovation/innovation.models.ts
@@ -34,6 +34,7 @@ export type InnovationSectionInfoDTO = {
   updatedAt: string;
   data: MappedObjectType;
   submittedAt: string;
+  actionsIds?: string[];
 }
 
 export type getInnovationInfoEndpointDTO = {

--- a/src/modules/stores/innovation/innovation.store.ts
+++ b/src/modules/stores/innovation/innovation.store.ts
@@ -10,7 +10,7 @@ import { WizardEngineModel } from '@modules/shared/forms';
 
 import { InnovationService } from './innovation.service';
 
-import { INNOVATION_SECTIONS, getSectionTitle, getSectionParentTitle, getSectionParentNumber } from './innovation.config';
+import { INNOVATION_SECTIONS, getSectionTitle, getSectionParentTitle, getSectionParentNumber, getSectionNumber } from './innovation.config';
 import { InnovationGroupedStatusEnum, InnovationSectionEnum, InnovationStatusEnum, InnovationSupportStatusEnum } from './innovation.enums';
 import {
   InnovationModel,
@@ -105,6 +105,10 @@ export class InnovationStore extends Store<InnovationModel> {
 
   getSectionParentNumber(sectionId: InnovationSectionEnum): string {
     return getSectionParentNumber(sectionId);
+  }
+
+  getSectionNumber(sectionId: InnovationSectionEnum): string {
+    return getSectionNumber(sectionId);
   }
 
   getSectionTitle(sectionId: InnovationSectionEnum | null): string {


### PR DESCRIPTION
- Added `actions from section page` that can be used to substitute the `action-info` page.
- Changed decline flow copy.
- Updated `getSectionInfo` and `getActionInfo` to match BE new contracts.