### PR TITLE
Change action status from IR from QA/A and other improvements

### DIFF
--- a/src/app/config/translations/en.ts
+++ b/src/app/config/translations/en.ts
@@ -101,7 +101,7 @@ export const locale = {
               cssColorClass: 'nhsuk-tag--blue'
             },
             IN_REVIEW: {
-              name: 'In review',
+              name: 'Submitted',
               description: 'The innovator has submitted information requested by an accessor and is waiting for the accessor to review this information.',
               cssColorClass: 'nhsuk-tag--yellow'
             },
@@ -113,7 +113,7 @@ export const locale = {
             DECLINED: {
               name: 'Declined',
               description: 'The innovator has declined the action requested.',
-              cssColorClass: 'nhsuk-tag--grey'
+              cssColorClass: 'nhsuk-tag--red'
             },
             COMPLETED: {
               name: 'Completed',
@@ -123,7 +123,7 @@ export const locale = {
             CANCELLED: {
               name: 'Cancelled',
               description: 'An accessor has cancelled the action.',
-              cssColorClass: 'nhsuk-tag--red'
+              cssColorClass: 'nhsuk-tag--dark-grey'
             }
           },
           activity_log_groups: {
@@ -222,8 +222,8 @@ export const locale = {
               message: `{{ actionUserName }} created an action for section "{{ sectionTitle }}"`
             },
             ACTION_STATUS_IN_REVIEW_UPDATE: {
-              title: 'Action changed to in review',
-              message: `{{ totalActions }} actions for "{{ sectionTitle }}" section were changed to "In review"`
+              title: 'Action changed to submitted',
+              message: `{{ totalActions }} actions for "{{ sectionTitle }}" section were changed to "Submitted"`
             },
             ACTION_STATUS_DECLINED_UPDATE: {
               title: 'Action declined',

--- a/src/modules/feature-modules/accessor/accessor-routing.module.ts
+++ b/src/modules/feature-modules/accessor/accessor-routing.module.ts
@@ -48,9 +48,9 @@ import { PageInnovationSupportStatusListComponent } from '@modules/shared/pages/
 import { PageExportRecordListComponent } from '@modules/shared/pages/innovation/export/export-record-list.component';
 import { PageExportRecordInfoComponent } from '@modules/shared/pages/innovation/export/export-record-info.component';
 import { InnovationExportRequestComponent } from './pages/innovation/export/export-request.component';
-import { PageInnovationActionTrackerInfoComponent } from '@modules/shared/pages/innovation/actions/action-tracker-info.component';
 import { PageInnovationActionTrackerListComponent } from '@modules/shared/pages/innovation/actions/action-tracker-list.component';
 import { PageInnovationDataSharingAndSupportComponent } from '@modules/shared/pages/innovation/data-sharing-and-support/data-sharing-and-support.component';
+import { PageInnovationActionSectionInfoComponent } from '@modules/shared/pages/innovation/actions/action-section-info.component';
 // // Innovations
 import { PageInnovationsAdvancedReviewComponent } from '@modules/shared/pages/innovations/innovations-advanced-review.component';
 // // Notifications.
@@ -186,9 +186,17 @@ const routes: Routes = [
                               }
                             ]
 
+                          },
+
+                          {
+                            path: 'actions',
+                            pathMatch: 'full',
+                            component: PageInnovationActionSectionInfoComponent,
+                            data: {
+                              breadcrumb: null,
+                              layout: { type: 'full' }
+                            }
                           }
-
-
                         ]
                       }
 
@@ -228,8 +236,8 @@ const routes: Routes = [
                     },
                     children: [
                       {
-                        path: '', pathMatch: 'full', component: PageInnovationActionTrackerInfoComponent,
-                        data: { breadcrumb: null }
+                        path: '', pathMatch: 'full', component: PageInnovationActionSectionInfoComponent,
+                        data: { breadcrumb: null, layout: { type: 'full' } }
                       },
                       {
                         path: 'edit', pathMatch: 'full', component: InnovationActionTrackerEditComponent,

--- a/src/modules/feature-modules/accessor/pages/innovation/action-tracker/action-tracker-cancel.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovation/action-tracker/action-tracker-cancel.component.ts
@@ -33,6 +33,10 @@ export class InnovationActionTrackerCancelComponent extends CoreComponent implem
 
     this.innovationsService.getActionInfo(this.innovationId, this.actionId).subscribe(response => {
 
+      if(response.createdBy.id !== this.stores.authentication.getUserId()) {
+        this.redirectTo(`/accessor/innovations/${this.innovationId}/action-tracker/${this.actionId}`);
+      }
+      
       this.setPageTitle(`Cancel action: ${response.name}`);
       this.setPageStatus('READY');
 

--- a/src/modules/feature-modules/accessor/pages/innovation/action-tracker/action-tracker-edit.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovation/action-tracker/action-tracker-edit.component.ts
@@ -80,7 +80,7 @@ export class InnovationActionTrackerEditComponent extends CoreComponent implemen
     this.innovationsService.updateAction(this.innovationId, this.actionId, body).subscribe({
       next: response => {
         const status = this.form.get('status')!.value as InnovationActionStatusEnum;
-        this.setRedirectAlertSuccess(`You have updated the status of this action to '${this.statusItems.find(item => item.value === status)?.label}'`, { message: 'The innovator will be notified of this status change' });
+        this.setRedirectAlertSuccess(`You have updated the status of this action to '${this.statusItems.find(item => item.value === status)?.label}'`, { message: `Send a message to innovator and explain why the submitted information is not sufficient.` });
         this.redirectTo(`/accessor/innovations/${this.innovationId}/action-tracker/${response.id}`);
       },
       error: () => this.setAlertError('An error occurred when updating an action. Please try again or contact us for further help')

--- a/src/modules/feature-modules/admin/admin-routing.module.ts
+++ b/src/modules/feature-modules/admin/admin-routing.module.ts
@@ -46,7 +46,6 @@ import { PageInnovationSectionEvidenceInfoComponent } from '@modules/shared/page
 import { PageInnovationSectionInfoComponent } from '@modules/shared/pages/innovation/sections/section-info.component';
 import { PageInnovationRecordComponent } from '@modules/shared/pages/innovation/record/innovation-record.component';
 import { PageActionStatusListComponent } from '@modules/shared/pages/innovation/actions/action-status-list.component';
-import { PageInnovationActionTrackerInfoComponent } from '@modules/shared/pages/innovation/actions/action-tracker-info.component';
 import { PageInnovationActionTrackerListComponent } from '@modules/shared/pages/innovation/actions/action-tracker-list.component';
 import { PageInnovationDataSharingAndSupportComponent } from '@modules/shared/pages/innovation/data-sharing-and-support/data-sharing-and-support.component';
 import { PageInnovationSupportStatusListComponent } from '@modules/shared/pages/innovation/support/innovation-support-status-list.component';
@@ -55,6 +54,7 @@ import { PageInnovationThreadMessagesListComponent } from '@modules/shared/pages
 import { PageInnovationAssessmentOverviewComponent } from '../../shared/pages/innovation/assessment/assessment-overview.component';
 import { PageInnovationActivityLogComponent } from '@modules/shared/pages/innovation/activity-log/innovation-activity-log.component';
 import { PageInnovationStatusListComponent } from '@modules/shared/pages/innovation/status/innovation-status-list.component';
+import { PageInnovationActionSectionInfoComponent } from '@modules/shared/pages/innovation/actions/action-section-info.component';
 
 // Wizards.
 import { WizardOrganisationUnitActivateComponent } from './wizards/organisation-unit-activate/organisation-unit-activate.component';
@@ -336,7 +336,7 @@ const routes: Routes = [
                     },
                     children: [
                       {
-                        path: '', pathMatch: 'full', component: PageInnovationActionTrackerInfoComponent,
+                        path: '', pathMatch: 'full', component: PageInnovationActionSectionInfoComponent,
                         data: { breadcrumb: null }
                       }
                     ]

--- a/src/modules/shared/pages/innovation/actions/action-section-info.component.html
+++ b/src/modules/shared/pages/innovation/actions/action-section-info.component.html
@@ -35,6 +35,10 @@
           <dt class="nhsuk-summary-list__key nhsuk-u-padding-3">Description</dt>
           <dd class="nhsuk-summary-list__value nhsuk-u-padding-3 textarea-info-section">{{ action.description }}</dd>
         </div>
+        <div class="nhsuk-summary-list__row" *ngIf="action.status === 'DECLINED'">
+          <dt class="nhsuk-summary-list__key nhsuk-u-padding-3">Reason for declining</dt>
+          <dd class="nhsuk-summary-list__value nhsuk-u-padding-3 textarea-info-section">{{ action.declineReason ?? '' }}</dd>
+        </div>
       </dl>
 
 
@@ -105,10 +109,25 @@
 
       <div class="nhsuk-card x-card-top-border">
         <div class="nhsuk-card__content">
-          <h2 class="nhsuk-card__heading nhsuk-heading-m">If you have any questions</h2>
-          <a routerLink="/innovator/innovations/{{ innovationId }}/threads">
-            Go to messages and start a new conversation with your supporting organisations.
-          </a>
+          
+          <ng-container *ngIf="stores.authentication.isInnovatorType()">
+
+            <h2 class="nhsuk-card__heading nhsuk-heading-m">If you have any questions</h2>
+            <a routerLink="/innovator/innovations/{{ innovationId }}/threads">
+              Go to messages and start a new conversation with your supporting organisations.
+            </a>
+
+          </ng-container>
+
+          <ng-container *ngIf="stores.authentication.isAccessorType()">
+
+            <h2 class="nhsuk-card__heading nhsuk-heading-m">Message the innovator</h2>
+            <a routerLink="/innovator/innovations/{{ innovationId }}/threads">
+              Go to messages and send a message to the innovator if you need to discuss more about it.
+            </a>
+
+          </ng-container>
+
         </div>
       </div>
 

--- a/src/modules/shared/pages/innovation/actions/action-section-info.component.html
+++ b/src/modules/shared/pages/innovation/actions/action-section-info.component.html
@@ -46,10 +46,17 @@
 
         <a routerLink="/accessor/innovations/{{ innovationId }}/record/sections/{{ action.section }}"
           class="nhsuk-button nhsuk-u-margin-right-3"> Review section </a>
+        
         <a *ngIf="action.status === 'IN_REVIEW'"
           routerLink="/accessor/innovations/{{ innovationId }}/action-tracker/{{ action.id }}/edit"
           class="nhsuk-button nhsuk-button--secondary">
           Update status
+        </a>
+
+        <a *ngIf="action.status === 'REQUESTED'"
+          routerLink="/accessor/innovations/{{ innovationId }}/action-tracker/{{ action.id }}/cancel"
+          class="nhsuk-button nhsuk-button--secondary">
+          Cancel action
         </a>
 
       </ng-container>

--- a/src/modules/shared/pages/innovation/actions/action-section-info.component.html
+++ b/src/modules/shared/pages/innovation/actions/action-section-info.component.html
@@ -53,7 +53,7 @@
           Update status
         </a>
 
-        <a *ngIf="action.status === 'REQUESTED'"
+        <a *ngIf="action.status === 'REQUESTED' && action.createdBy.id === stores.authentication.getUserId()"
           routerLink="/accessor/innovations/{{ innovationId }}/action-tracker/{{ action.id }}/cancel"
           class="nhsuk-button nhsuk-button--secondary">
           Cancel action
@@ -112,7 +112,7 @@
 
     </div>
 
-    <div class="nhsuk-grid-column-one-third">
+    <div class="nhsuk-grid-column-one-third" *ngIf="stores.authentication.isInnovatorType() || stores.authentication.isAccessorType()">
 
       <div class="nhsuk-card x-card-top-border">
         <div class="nhsuk-card__content">

--- a/src/modules/shared/pages/innovation/actions/action-tracker-list.component.ts
+++ b/src/modules/shared/pages/innovation/actions/action-tracker-list.component.ts
@@ -75,7 +75,7 @@ export class PageInnovationActionTrackerListComponent extends CoreComponent impl
     this.closedActionsList.setFilters({
       innovationId: this.innovationId,
       fields: ['notifications'],
-      status: [InnovationActionStatusEnum.DECLINED, InnovationActionStatusEnum.COMPLETED, InnovationActionStatusEnum.DELETED]
+      status: [InnovationActionStatusEnum.DECLINED, InnovationActionStatusEnum.COMPLETED, InnovationActionStatusEnum.DELETED, InnovationActionStatusEnum.CANCELLED]
     });
     
     this.innovationsService.getActionsList(this.openedActionsList.getAPIQueryParams()).subscribe((openedActions) => {

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.html
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.html
@@ -179,6 +179,8 @@
                 <ng-container *ngSwitchCase="'accessor'">
                   <span *ngIf="section.openActionsCount >= 1" class="float-r">
                     <theme-tag
+                      routerLink="{{ baseUrl }}/{{section.id}}/actions"
+                      class="cursor-pointer"
                       type="{{ 'shared.catalog.innovation.action_status.IN_REVIEW.cssColorClass' | translate }}"
                       label="{{ section.openActionsCount + ' ' + ('dictionary.action' | pluralTranslate: section.openActionsCount | translate) + ' ' + ('shared.catalog.innovation.action_status.IN_REVIEW.name' | translate | lowercase) }}">
                     </theme-tag>

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.html
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.html
@@ -182,7 +182,7 @@
                       routerLink="{{ baseUrl }}/{{section.id}}/actions"
                       class="cursor-pointer"
                       type="{{ 'shared.catalog.innovation.action_status.IN_REVIEW.cssColorClass' | translate }}"
-                      label="{{ section.openActionsCount + ' ' + ('dictionary.action' | pluralTranslate: section.openActionsCount | translate) + ' ' + ('shared.catalog.innovation.action_status.IN_REVIEW.name' | translate | lowercase) }}">
+                      label="{{ section.openActionsCount + ' ' + ('shared.catalog.innovation.action_status.IN_REVIEW.name' | translate | lowercase) + ' ' + ('dictionary.action' | pluralTranslate: section.openActionsCount | translate) }}">
                     </theme-tag>
                   </span>
                 </ng-container>

--- a/src/modules/shared/services/innovations.dtos.ts
+++ b/src/modules/shared/services/innovations.dtos.ts
@@ -145,7 +145,7 @@ export type InnovationActionInfoDTO = {
   name: string,
   description: string,
   createdAt: DateISOType,
-  createdBy: { name: string, organisationUnit: string },
+  createdBy: { id: string, name: string, organisationUnit: string },
   declineReason?: string,
 };
 

--- a/src/modules/shared/services/innovations.dtos.ts
+++ b/src/modules/shared/services/innovations.dtos.ts
@@ -145,7 +145,8 @@ export type InnovationActionInfoDTO = {
   name: string,
   description: string,
   createdAt: DateISOType,
-  createdBy: { name: string, organisationUnit: string };
+  createdBy: { name: string, organisationUnit: string },
+  declineReason?: string,
 };
 
 

--- a/src/modules/shared/services/innovations.service.ts
+++ b/src/modules/shared/services/innovations.service.ts
@@ -382,7 +382,8 @@ export class InnovationsService extends CoreService {
         description: response.description,
         section: response.section,
         createdAt: response.createdAt,
-        createdBy: response.createdBy
+        createdBy: response.createdBy,
+        declineReason: response.declineReason
       }))
     );
 

--- a/src/modules/stores/innovation/innovation.models.ts
+++ b/src/modules/stores/innovation/innovation.models.ts
@@ -239,7 +239,7 @@ export const INNOVATION_SECTION_ACTION_STATUS = {
     description: ''
   },
   IN_REVIEW: {
-    label: 'In review',
+    label: 'Submitted',
     cssClass: 'nhsuk-tag--yellow',
     description: 'The innovation owner has submitted information requested by an accessor and are waiting for them to review it.'
   },
@@ -250,7 +250,7 @@ export const INNOVATION_SECTION_ACTION_STATUS = {
   },
   DECLINED: {
     label: 'Declined',
-    cssClass: 'nhsuk-tag--grey',
+    cssClass: 'nhsuk-tag--red',
     description: 'The innovation owner has declined the action requested.'
   },
   COMPLETED: {
@@ -260,7 +260,7 @@ export const INNOVATION_SECTION_ACTION_STATUS = {
   },
   CANCELLED: {
     label: 'Cancelled',
-    cssClass: 'nhsuk-tag--red',
+    cssClass: 'nhsuk-tag--dark-grey',
     description: 'An accessor has cancelled the action.'
   }
 };


### PR DESCRIPTION
- Allow QA/A to change action status from IR.
- Added existing cancel button flow to `action-section-info`, and fix button was appearing for all users.
- Change labels from actions `IN_REVIEW` to `SUBMITTED`.
- Change admin action info component to the new one (`action-section-info`).