### PR TITLE
Fixes and improvements around action and section info

### DIFF
--- a/src/app/base/core.component.ts
+++ b/src/app/base/core.component.ts
@@ -166,6 +166,9 @@ export class CoreComponent implements OnDestroy {
   setRedirectAlertSuccess(title: string, options?: { message?: string, width?: ContextPageLayoutType['alert']['width'] }): void {
     this.stores.context.setPageAlert({ type: 'SUCCESS', title, message: options?.message, width: options?.width, persistOneRedirect: true });
   }
+  setRedirectAlertInformation(title: string, options?: { message?: string, width?: ContextPageLayoutType['alert']['width'] }): void {
+    this.stores.context.setPageAlert({ type: 'INFORMATION', title, message: options?.message, width: options?.width, persistOneRedirect: true });
+  }
   setRedirectAlertError(message: string, options?: { message?: string, itemsList?: ContextPageLayoutType['alert']['itemsList'], width?: ContextPageLayoutType['alert']['width'] }): void {
     this.stores.context.setPageAlert({ type: 'ERROR', title: 'There is a problem', message, width: options?.width, persistOneRedirect: true });
   }

--- a/src/modules/feature-modules/accessor/pages/innovation/action-tracker/action-tracker-edit.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovation/action-tracker/action-tracker-edit.component.ts
@@ -80,7 +80,12 @@ export class InnovationActionTrackerEditComponent extends CoreComponent implemen
     this.innovationsService.updateAction(this.innovationId, this.actionId, body).subscribe({
       next: response => {
         const status = this.form.get('status')!.value as InnovationActionStatusEnum;
-        this.setRedirectAlertSuccess(`You have updated the status of this action to '${this.statusItems.find(item => item.value === status)?.label}'`, { message: `Send a message to innovator and explain why the submitted information is not sufficient.` });
+        
+        const message = status === InnovationActionStatusEnum.COMPLETED 
+          ? 'The innovator will be notified of this status change.'
+          : 'Send a message to innovator and explain why the submitted information is not sufficient.'
+        
+        this.setRedirectAlertSuccess(`You have updated the status of this action to '${this.statusItems.find(item => item.value === status)?.label}'`, { message });
         this.redirectTo(`/accessor/innovations/${this.innovationId}/action-tracker/${response.id}`);
       },
       error: () => this.setAlertError('An error occurred when updating an action. Please try again or contact us for further help')

--- a/src/modules/feature-modules/innovator/pages/innovation/action-complete-confirmation/action-complete-confirmation.component.html
+++ b/src/modules/feature-modules/innovator/pages/innovation/action-complete-confirmation/action-complete-confirmation.component.html
@@ -16,14 +16,14 @@
               <div class="nhsuk-radios__item nhsuk-u-margin-bottom-2">
                 <input formControlName="actionComplete" id="actionComplete-yes" type="radio" name="actionComplete" [value]="true" class="nhsuk-radios__input" />
                 <label for="actionComplete-yes" class="nhsuk-label nhsuk-radios__label nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-2">
-                  Yes, I've completed {{actionsCounter === 1 ? 'this action' : 'these actions'}} 
+                  Yes, I have completed it
                 </label>
               </div>
 
               <div class="nhsuk-radios__item">
                 <input formControlName="actionComplete" id="actionComplete-no" type="radio" name="actionComplete" [value]="false" class="nhsuk-radios__input" />
                 <label for="actionComplete-no" class="nhsuk-label nhsuk-radios__label nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-2">
-                  Not yet, I'll complete them later
+                  Not yet, I will complete it later
                 </label>
               </div>
             </div>

--- a/src/modules/feature-modules/innovator/pages/innovation/action-complete-confirmation/action-complete-confirmation.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation/action-complete-confirmation/action-complete-confirmation.component.ts
@@ -66,6 +66,7 @@ export class InnovationActionCompleteConfirmationComponent extends CoreComponent
   }
 
   private onCompleteSectionLater(): void {
+    this.setRedirectAlertInformation('Your section will be in draft until you complete all actions requested for this section.')
     this.redirectTo(`innovator/innovations/${this.innovationId}/record/sections/${this.sectionId}`);
   }
 }

--- a/src/modules/feature-modules/innovator/pages/innovation/record/section-edit.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation/record/section-edit.component.ts
@@ -190,21 +190,28 @@ export class InnovationSectionEditComponent extends CoreComponent implements OnI
           }
           else {
 
-            this.setPageTitle('Check your answers', { size: 'l' });
+            this.setPageStatus('LOADING');
 
-            const validInformation = this.wizard.validateData();
+            this.stores.innovation.getSectionInfo$(this.innovation.id, this.sectionId).subscribe((sectionInfo) => {
 
+              const validInformation = this.wizard.validateData();
 
-            if (this.hasRequestActions) {
-              this.submitRequestedActionsButton.isActive = validInformation.valid;
-            } else {
-              this.submitButton.isActive = validInformation.valid;
+              if (!validInformation.valid) {
+                this.alertErrorsList = validInformation.errors;
+                this.setAlertError(`Please verify what's missing with your answers`, { itemsList: this.alertErrorsList, width: '2.thirds' });
+              }
+
+              if (this.hasRequestActions && sectionInfo.status === 'DRAFT') {
+                this.submitRequestedActionsButton.isActive = validInformation.valid;
+              } else {
+                this.submitButton.isActive = validInformation.valid;
+              }
+
+              this.setPageTitle('Check your answers', { size: 'l' });
+
+              this.setPageStatus('READY');
             }
-
-            if (!validInformation.valid) {
-              this.alertErrorsList = validInformation.errors;
-              this.setAlertError(`Please verify what's missing with your answers`, { itemsList: this.alertErrorsList, width: '2.thirds' });
-            }
+            );
 
           }
 

--- a/src/modules/shared/pages/innovation/actions/action-section-info.component.html
+++ b/src/modules/shared/pages/innovation/actions/action-section-info.component.html
@@ -28,7 +28,7 @@
         </div>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key nhsuk-u-padding-3">Section</dt>
-          <dd class="nhsuk-summary-list__value nhsuk-u-padding-3">{{ stores.innovation.getSectionNumber(action.section) }}: {{
+          <dd class="nhsuk-summary-list__value nhsuk-u-padding-3">{{ stores.innovation.getSectionNumber(action.section) }} {{
             stores.innovation.getSectionTitle(action.section) }}</dd>
         </div>
         <div class="nhsuk-summary-list__row">
@@ -129,7 +129,7 @@
           <ng-container *ngIf="stores.authentication.isAccessorType()">
 
             <h2 class="nhsuk-card__heading nhsuk-heading-m">Message the innovator</h2>
-            <a routerLink="/innovator/innovations/{{ innovationId }}/threads">
+            <a routerLink="/accessor/innovations/{{ innovationId }}/threads">
               Go to messages and send a message to the innovator if you need to discuss more about it.
             </a>
 

--- a/src/modules/shared/pages/innovation/sections/section-info.component.html
+++ b/src/modules/shared/pages/innovation/sections/section-info.component.html
@@ -11,7 +11,7 @@
           <span class="nhsuk-u-margin-right-2"></span>
           <span *ngIf="section.status.id === 'SUBMITTED' && section.date !== ''">Last submitted {{ section.date | date: ('app.date_formats.long_date_time' | translate) }}</span> 
           <span *ngIf="section.status.id === 'DRAFT' && ['innovator'].includes(module)">This section is in draft. Check answers and submit updates.</span> 
-          <span *ngIf="section.status.id !== 'SUBMITTED' && ['accessor'].includes(module)">This section is in {{ 'shared.catalog.innovation.section_status.' + section.status.id + '.name' | translate }}</span> 
+          <span *ngIf="section.status.id === 'NOT_STARTED'">This section has not been started yet.</span> 
         </p>
       </div>
 
@@ -65,10 +65,10 @@
         <div>
           <button *ngIf="section.hasEvidences && !section.isNotStarted" routerLink="evidences/new" class="nhsuk-button nhsuk-button--secondary"> Add evidence </button>
         </div>
-        <div *ngIf="section.status.id === 'DRAFT'">
+        <div>
           <button *ngIf="section.showSubmitButton" (click)="onSubmitSection()" class="nhsuk-button nhsuk-u-margin-right-3"> Confirm section answers </button>
 
-          <button *ngIf="section.actions > 0" routerLink="/innovator/innovations/{{ innovation.id }}/record/sections/{{ section.id }}/confirm-update" class="nhsuk-button nhsuk-u-margin-right-3"> Submit updates </button>
+          <button *ngIf="section.showSubmitUpdatesButton" routerLink="/innovator/innovations/{{ innovation.id }}/record/sections/{{ section.id }}/confirm-update" class="nhsuk-button nhsuk-u-margin-right-3"> Submit updates </button>
         </div>
       </ng-container>
 


### PR DESCRIPTION
- Added new informational alert
- Changed copy on confirm action changes and added new informational alert
- Fixed wrong message redirection on action section info (on QA/A) side
- Fixed empty message on section message when section is in Not started status
- Fixed bug where section could be submitted even tough no changes were made
- Fixed update action alert message (was the same for both status)