### PR TITLE
Fix accessor organisation unit name

### DIFF
--- a/src/modules/stores/authentication/authentication.store.ts
+++ b/src/modules/stores/authentication/authentication.store.ts
@@ -97,7 +97,7 @@ export class AuthenticationStore extends Store<AuthenticationModel> {
   }
 
   getAccessorOrganisationUnitName(): string {
-    return (this.state.user?.organisations[0]?.organisationUnits || [])[0]?.name || '';
+    return this.getUserContextInfo().organisation?.organisationUnit?.name || '';
   }
 
   getUserInfo(): Required<AuthenticationModel>['user'] {


### PR DESCRIPTION
get organisation unit from user context instead of first index of organisation unit list