### PR TITLE
Distinguish messages created by current user in different organisation units

### DIFF
--- a/src/modules/shared/pages/innovation/messages/threads-list.component.html
+++ b/src/modules/shared/pages/innovation/messages/threads-list.component.html
@@ -62,7 +62,7 @@
                 <p class="nhsuk-body-s nhsuk-u-margin-0">{{ item.lastMessage.createdAt | date: ('app.date_formats.short_date_time' | translate) }}</p>
                 <p class="nhsuk-hint nhsuk-u-font-size-14 nhsuk-u-margin-0">
 
-                  <ng-container *ngIf="item.lastMessage.createdBy.id === selfUser.id; else notSelfUser">
+                  <ng-container *ngIf="item.lastMessage.createdBy.id === selfUser.id && item.lastMessage.createdBy.organisationUnit?.id === selfUser.organisationUnitId; else notSelfUser">
                     {{ item.lastMessage.createdBy.name }} (me)
                   </ng-container>
 

--- a/src/modules/shared/pages/innovation/messages/threads-list.component.ts
+++ b/src/modules/shared/pages/innovation/messages/threads-list.component.ts
@@ -14,7 +14,7 @@ import { GetThreadsListDTO, InnovationsService } from '@modules/shared/services/
 })
 export class PageInnovationThreadsListComponent extends CoreComponent implements OnInit {
 
-  selfUser: { id: string };
+  selfUser: { id: string, organisationUnitId?: string };
   innovation: ContextInnovationType;
   tableList = new TableModel<GetThreadsListDTO['threads'][0]>({ pageSize: 10 });
 
@@ -31,7 +31,7 @@ export class PageInnovationThreadsListComponent extends CoreComponent implements
     super();
     this.setPageTitle('Messages');
 
-    this.selfUser = { id: this.stores.authentication.getUserId() };
+    this.selfUser = { id: this.stores.authentication.getUserId(), organisationUnitId: this.stores.authentication.getUserContextInfo().organisation?.organisationUnit.id };
 
     this.innovation = this.stores.context.getInnovation();
 


### PR DESCRIPTION
Only show (me) when the last message sent was created by the current user in the current organisation unit context