### PR TITLE
QA/A data sharing and support page

### DIFF
--- a/src/modules/feature-modules/accessor/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/accessor/base/sidebar-innovation-menu-outlet.component.ts
@@ -51,7 +51,7 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
         { label: 'Innovation record', url: `/accessor/innovations/${innovation.id}/record` },
         { label: 'Action tracker', url: `/accessor/innovations/${innovation.id}/action-tracker` },
         { label: 'Messages', url: `/accessor/innovations/${innovation.id}/threads` },
-        { label: 'Data sharing and support', url: `/accessor/innovations/${innovation.id}/support` },
+        { label: 'Support status', url: `/accessor/innovations/${innovation.id}/support` },
         { label: 'Activity log', url: `/accessor/innovations/${innovation.id}/activity-log` }
       ];
     }

--- a/src/modules/feature-modules/accessor/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/accessor/base/sidebar-innovation-menu-outlet.component.ts
@@ -51,7 +51,7 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
         { label: 'Innovation record', url: `/accessor/innovations/${innovation.id}/record` },
         { label: 'Action tracker', url: `/accessor/innovations/${innovation.id}/action-tracker` },
         { label: 'Messages', url: `/accessor/innovations/${innovation.id}/threads` },
-        { label: 'Support status', url: `/accessor/innovations/${innovation.id}/support` },
+        { label: 'Data sharing and support', url: `/accessor/innovations/${innovation.id}/support` },
         { label: 'Activity log', url: `/accessor/innovations/${innovation.id}/activity-log` }
       ];
     }

--- a/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.ts
@@ -54,7 +54,7 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
         { label: 'Innovation record', url: `/assessment/innovations/${innovation.id}/record` },
         { label: 'Action tracker', url: `/assessment/innovations/${innovation.id}/action-tracker` },
         { label: 'Messages', url: `/assessment/innovations/${innovation.id}/threads` },
-        { label: 'Support status', url: `/assessment/innovations/${innovation.id}/support` }
+        { label: 'Data sharing and support', url: `/assessment/innovations/${innovation.id}/support` }
       ];
   
       if (innovation.status === InnovationStatusEnum.IN_PROGRESS) {

--- a/src/modules/shared/pages/innovation/data-sharing-and-support/data-sharing-and-support.component.html
+++ b/src/modules/shared/pages/innovation/data-sharing-and-support/data-sharing-and-support.component.html
@@ -24,18 +24,17 @@
 
       </ng-container>
 
-      <ng-container *ngIf="stores.authentication.isAccessorType()">
-
-        <div class="nhsuk-body-m nhsuk-u-margin-0 nhsuk-u-padding-bottom-3">
+      <ul class="nhsuk-list">
+        <li>
           <ng-container *ngTemplateOutlet="icon; context: { shared: true }"></ng-container>
           Organisations that have access to the innovation because they have been invited to support it or the innovator has shared their data with them.
-        </div>
-        <div class="nhsuk-body-m nhsuk-u-margin-0 nhsuk-u-padding-bottom-5">
+        </li>
+        <li>
           <ng-container *ngTemplateOutlet="icon; context: { shared: false }"></ng-container>
           Organisations that do not have access to the innovation.
-        </div>
-
-      </ng-container>
+        </li>
+      </ul>
+      
 
 
       <ul class="nhsuk-list">

--- a/src/modules/shared/pages/innovation/data-sharing-and-support/data-sharing-and-support.component.html
+++ b/src/modules/shared/pages/innovation/data-sharing-and-support/data-sharing-and-support.component.html
@@ -13,13 +13,26 @@
 
       </ng-container>
 
-      <ng-container *ngIf="stores.authentication.isAssessmentType() && !innovation.owner.isActive">
+      <ng-container *ngIf="(stores.authentication.isAssessmentType() || stores.authentication.isAccessorType()) && !innovation.owner.isActive">
 
         <div *ngIf="!innovation.owner.isActive" class="nhsuk-warning-callout nhsuk-u-margin-top-0">
           <div class="nhsuk-heading-m nhsuk-warning-callout__label">
             <span role="text"> <span class="nhsuk-u-visually-hidden">Important: </span> User Locked </span>
           </div>
           <p> Please note that the innovator {{ innovation.owner.name }} is currently locked. </p>
+        </div>
+
+      </ng-container>
+
+      <ng-container *ngIf="stores.authentication.isAccessorType()">
+
+        <div class="nhsuk-body-m nhsuk-u-margin-0 nhsuk-u-padding-bottom-3">
+          <ng-container *ngTemplateOutlet="icon; context: { shared: true }"></ng-container>
+          Organisations that have access to the innovation because they have been invited to support it or the innovator has shared their data with them.
+        </div>
+        <div class="nhsuk-body-m nhsuk-u-margin-0 nhsuk-u-padding-bottom-5">
+          <ng-container *ngTemplateOutlet="icon; context: { shared: false }"></ng-container>
+          Organisations that do not have access to the innovation.
         </div>
 
       </ng-container>
@@ -48,7 +61,7 @@
             <div class="d-flex nhsuk-body-m nhsuk-u-margin-0 nhsuk-u-padding-top-3 nhsuk-u-padding-bottom-3" [ngClass]="{'bottom-border-separator': organisation.showHideStatus !== 'opened'}">
               <dt class="d-flex nhsuk-u-font-weight-normal">
 
-                <ng-container *ngIf="['ADMIN','INNOVATOR','ASSESSMENT'].includes(userType)">
+                <ng-container>
                   <ng-container *ngTemplateOutlet="icon; context: { shared: organisation.shared }"></ng-container>
                 </ng-container>
                 
@@ -56,7 +69,7 @@
               </dt>
               <dd class="ml-auto">
 
-                <span *ngIf="!organisation.shared && ['INNOVATOR','ADMIN','ASSESSMENT'].includes(userType)">Not shared</span>
+                <span *ngIf="!organisation.shared">Not shared</span>
 
                 <ng-container *ngIf="organisation.shared !== false">
 

--- a/src/modules/shared/pages/innovation/data-sharing-and-support/data-sharing-and-support.component.ts
+++ b/src/modules/shared/pages/innovation/data-sharing-and-support/data-sharing-and-support.component.ts
@@ -69,24 +69,7 @@ export class PageInnovationDataSharingAndSupportComponent extends CoreComponent 
 
     this.isQualifyingAccessorRole = this.stores.authentication.isQualifyingAccessorRole();
 
-    switch (this.userType) {
-      case UserRoleEnum.ASSESSMENT:
-        this.setPageTitle('Support status', { hint: 'All organisations' });
-        break;
-
-      case UserRoleEnum.ADMIN:
-        this.setPageTitle('Data sharing and support', { hint: `Innovation ${this.innovation.name}` });
-        break;
-
-      case UserRoleEnum.ACCESSOR:
-      case UserRoleEnum.QUALIFYING_ACCESSOR:
-        this.setPageTitle('Data sharing and support', { hint: 'All organisations' });
-        break;
-
-      default:
-        this.setPageTitle('Data sharing and support');
-    }
-
+    this.setPageTitle('Data sharing and support', { hint: 'All organisations' });
   }
 
   ngOnInit(): void {

--- a/src/modules/shared/pages/innovation/data-sharing-and-support/data-sharing-and-support.component.ts
+++ b/src/modules/shared/pages/innovation/data-sharing-and-support/data-sharing-and-support.component.ts
@@ -80,7 +80,7 @@ export class PageInnovationDataSharingAndSupportComponent extends CoreComponent 
 
       case UserRoleEnum.ACCESSOR:
       case UserRoleEnum.QUALIFYING_ACCESSOR:
-        this.setPageTitle('Support status', { hint: 'All organisations' });
+        this.setPageTitle('Data sharing and support', { hint: 'All organisations' });
         break;
 
       default:
@@ -109,7 +109,7 @@ export class PageInnovationDataSharingAndSupportComponent extends CoreComponent 
       subscriptions.organisationSuggestions = this.innovationService.getInnovationOrganisationSuggestions(this.innovationId);
     }
     
-    if(this.userType === UserRoleEnum.ADMIN || this.userType === UserRoleEnum.ASSESSMENT) {
+    if(this.userType === UserRoleEnum.ADMIN || this.userType === UserRoleEnum.ASSESSMENT || this.userType === UserRoleEnum.ACCESSOR || this.userType === UserRoleEnum.QUALIFYING_ACCESSOR) {
       subscriptions.innovationShares = this.innovationsService.getInnovationSharesList(this.innovationId);
     }
 
@@ -120,7 +120,7 @@ export class PageInnovationDataSharingAndSupportComponent extends CoreComponent 
         this.shares = (results.innovationShares ?? []).map(item => ({ organisationId: item.organisation.id }));
       }
 
-      if (this.userType === UserRoleEnum.ADMIN || this.userType === UserRoleEnum.ASSESSMENT) {
+      if (this.userType === UserRoleEnum.ADMIN || this.userType === UserRoleEnum.ASSESSMENT || this.userType === UserRoleEnum.ACCESSOR || this.userType === UserRoleEnum.QUALIFYING_ACCESSOR) {
         this.shares = (results.innovationShares ?? []).map(item => ({ organisationId: item.organisation.id }));
       }
 
@@ -135,7 +135,7 @@ export class PageInnovationDataSharingAndSupportComponent extends CoreComponent 
               organisationUnits: [],
               status: results.innovationSupports.find(item => item.organisation.id === organisation.id)?.status || InnovationSupportStatusEnum.UNASSIGNED,
             },
-            ...([UserRoleEnum.ADMIN, UserRoleEnum.INNOVATOR, UserRoleEnum.ASSESSMENT].includes(this.userType as UserRoleEnum) ? { shared: ((results.innovationShares ?? []).findIndex(item => item.organisation.id === organisation.id) > -1) } : {}),
+            ...([UserRoleEnum.ADMIN, UserRoleEnum.INNOVATOR, UserRoleEnum.ASSESSMENT, UserRoleEnum.ACCESSOR, UserRoleEnum.QUALIFYING_ACCESSOR].includes(this.userType as UserRoleEnum) ? { shared: ((results.innovationShares ?? []).findIndex(item => item.organisation.id === organisation.id) > -1) } : {}),
             showHideStatus: 'hidden',
             showHideText: null,
             showHideDescription: null
@@ -151,7 +151,7 @@ export class PageInnovationDataSharingAndSupportComponent extends CoreComponent 
                 status: results.innovationSupports.find(item => item.organisation.unit.id === organisationUnit.id)?.status || InnovationSupportStatusEnum.UNASSIGNED
               }))
             },
-            ...([UserRoleEnum.ADMIN, UserRoleEnum.INNOVATOR, UserRoleEnum.ASSESSMENT].includes(this.userType as UserRoleEnum) ? { shared: ((results.innovationShares ?? []).findIndex(item => item.organisation.id === organisation.id) > -1) } : {}),
+            ...([UserRoleEnum.ADMIN, UserRoleEnum.INNOVATOR, UserRoleEnum.ASSESSMENT, UserRoleEnum.ACCESSOR, UserRoleEnum.QUALIFYING_ACCESSOR].includes(this.userType as UserRoleEnum) ? { shared: ((results.innovationShares ?? []).findIndex(item => item.organisation.id === organisation.id) > -1) } : {}),
             showHideStatus: 'closed',
             showHideText: organisation.organisationUnits.length === 0 ? null : `Show ${organisation.organisationUnits.length} units`,
             showHideDescription: `that belong to the ${organisation.name}`

--- a/src/modules/shared/pages/innovation/messages/thread-new.component.html
+++ b/src/modules/shared/pages/innovation/messages/thread-new.component.html
@@ -12,7 +12,10 @@
       </p>
 
       <p *ngIf="isNotInnovator()">
-        The innovator will be notified. Your messages can be seen by everyone who has access to this innovation. <a routerLink="../../support" target="_blank" rel="noopener noreferrer"> View a list of this innovation's data sharing preferences (opens in new window).</a>
+        The innovator will be notified. Your messages can be seen by everyone who has access to this innovation.
+        <a [routerLink]="stores.authentication.isAccessorType() ? '../../support/organisations' : '../../support'" target="_blank" rel="noopener noreferrer">
+          View a list of this innovation's data sharing preferences (opens in new window).
+        </a>
       </p>
 
       <form [formGroup]="form" (ngSubmit)="onSubmit()">

--- a/src/modules/shared/pages/innovation/messages/threads-list.component.html
+++ b/src/modules/shared/pages/innovation/messages/threads-list.component.html
@@ -16,7 +16,10 @@
         <p *ngIf="isNotInnovator()">Messages is the space to engage in conversations with the innovator and with other organisations supporting this innovation.</p>
 
         <p>
-          Your messages can be seen by everyone who has access to this innovation.  <a routerLink="../support" target="_blank" rel="noopener noreferrer">View a list of this innovation's data sharing preferences (opens in new window).</a>
+          Your messages can be seen by everyone who has access to this innovation.
+          <a [routerLink]="stores.authentication.isAccessorType() ? '../support/organisations' : '../support'" target="_blank" rel="noopener noreferrer">
+            View a list of this innovation's data sharing preferences (opens in new window).
+          </a>
         </p>
         
         <button class="nhsuk-button" [disabled]="!isInnovationSubmitted()" routerLink="new"> Start a new conversation </button>


### PR DESCRIPTION
- Change data sharing and support page for QA/A
- Add shared status icon explanation for data sharing page of all user roles
- Uniform title for data sharing and support page for all user roles

![image](https://user-images.githubusercontent.com/117731486/219033733-1309a5d3-1d12-4685-8790-e665bffd5c89.png)
