### PR TITLE
Fix bug when close actions details was clicked

### DIFF
--- a/src/modules/shared/pages/innovation/actions/action-tracker-list.component.html
+++ b/src/modules/shared/pages/innovation/actions/action-tracker-list.component.html
@@ -86,8 +86,8 @@
     </ng-container>
 
     <h2 class="nhsuk-u-margin-bottom-2">Closed actions for innovation record</h2>
-    <details class="nhsuk-details nhsuk-u-padding-top-5" (click)="handleClosedActionsTableClick()">
-      <summary class="nhsuk-details__summary">
+    <details class="nhsuk-details nhsuk-u-padding-top-5">
+      <summary class="nhsuk-details__summary" (click)="handleClosedActionsTableClick()">
         <span class="nhsuk-details__summary-text">
           All closed actions
         </span>


### PR DESCRIPTION
- The request was made when the user clicked everywhere inside of the "details" div, when in reality it should be only on the summary label.