### PR TITLE
Set empty string as null

### DIFF
--- a/src/modules/feature-modules/innovator/pages/innovation/record/section-edit.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation/record/section-edit.component.ts
@@ -120,6 +120,13 @@ export class InnovationSectionEditComponent extends CoreComponent implements OnI
 
     const formData = this.formEngineComponent?.getFormValues();
 
+    Object.keys(formData?.data || {}).forEach(key => {
+      const value = formData!.data[key];
+      if (typeof value === "string") {
+        formData!.data[key] = value === '' ? null : value;
+      }
+    });
+
     if (action === 'previous') {
       this.wizard.addAnswers(formData?.data || {}).runRules();
       if (this.wizard.isFirstStep()) { this.redirectTo(this.baseUrl); }

--- a/src/modules/feature-modules/innovator/pages/innovation/record/section-edit.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation/record/section-edit.component.ts
@@ -11,6 +11,7 @@ import { UrlModel } from '@app/base/models';
 import { ContextInnovationType } from '@modules/stores/context/context.types';
 import { InnovationSectionEnum } from '@modules/stores/innovation';
 import { INNOVATION_SECTIONS } from '@modules/stores/innovation/innovation.config';
+import { UtilsHelper } from '@app/base/helpers';
 
 
 @Component({
@@ -123,7 +124,7 @@ export class InnovationSectionEditComponent extends CoreComponent implements OnI
     Object.keys(formData?.data || {}).forEach(key => {
       const value = formData!.data[key];
       if (typeof value === "string") {
-        formData!.data[key] = value === '' ? null : value;
+        formData!.data[key] = UtilsHelper.isEmpty(value) ? null : value;
       }
     });
 


### PR DESCRIPTION
I'm doing a simple conversion from empty string to `null`, since the bug is due to the backend endpoint not accepting empty strings while the form component sets the value for text inputs as empty string ` ''`  when the user writes some text and erases it after.