### PR TITLE
Fix/issue session reload

### DIFF
--- a/src/modules/core/interceptors/api-in.interceptor.ts
+++ b/src/modules/core/interceptors/api-in.interceptor.ts
@@ -1,10 +1,13 @@
-import { Injectable } from '@angular/core';
-import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor, HttpErrorResponse } from '@angular/common/http';
-import { catchError, Observable, throwError } from 'rxjs';
+import { isPlatformBrowser } from '@angular/common';
+import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { EMPTY, Observable, catchError, throwError } from 'rxjs';
 
 
 @Injectable()
 export class ApiInInterceptor implements HttpInterceptor {
+
+  constructor(@Inject(PLATFORM_ID) private platformId: object) { }
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 
@@ -15,7 +18,13 @@ export class ApiInInterceptor implements HttpInterceptor {
         // console.log('APIin', error);
 
         if (error.status === 401) {
-          return next.handle(request.clone());
+          // If 401 and browser reload the page to fetch a new token from the identity provider.
+          if (isPlatformBrowser(this.platformId)) {
+            location.reload();
+            return EMPTY;
+          } else {
+            return next.handle(request.clone());
+          }
         } else {
 
           // If error is handled on the subscription itself, this error will be ignored!

--- a/src/modules/theme/components/activity-timeout/activity-timeout.component.ts
+++ b/src/modules/theme/components/activity-timeout/activity-timeout.component.ts
@@ -1,7 +1,6 @@
 import { isPlatformBrowser } from '@angular/common';
 import { Component, EventEmitter, Inject, Input, OnDestroy, OnInit, Output, PLATFORM_ID } from '@angular/core';
-import { LocalStorageHelper } from '@app/base/helpers';
-import { interval, Subscription } from 'rxjs';
+import { Subscription, interval } from 'rxjs';
 
 
 @Component({
@@ -49,9 +48,8 @@ export class ActivityTimeoutComponent implements OnInit, OnDestroy {
 
       this.timeoutSubscription = interval(this.CHECK_INTERVAL * 1000).subscribe(() => this.check());
 
+      // console.log('Timeout started', this.minutesToLogout);
     }
-
-    console.log('Timeout started', this.minutesToLogout);
 
   }
 

--- a/src/server/routes/api.routes.ts
+++ b/src/server/routes/api.routes.ts
@@ -55,7 +55,7 @@ apiRouter.all(`${ENVIRONMENT.BASE_PATH}/api/*`, async (req, res) => {
 
   const requestHandler = getRequestHandler();
   const oid = req.session.id;
-  const accessToken = await getAccessTokenBySessionId(oid || '');
+  const accessToken = await getAccessTokenBySessionId(oid);
 
   if (oid && accessToken) {
 

--- a/src/server/routes/api.routes.ts
+++ b/src/server/routes/api.routes.ts
@@ -51,11 +51,11 @@ function parseAPIUrl(url: string): string {
 }
 
 // Authenticated API proxy endpoints.
-apiRouter.all(`${ENVIRONMENT.BASE_PATH}/api/*`, (req, res) => {
+apiRouter.all(`${ENVIRONMENT.BASE_PATH}/api/*`, async (req, res) => {
 
   const requestHandler = getRequestHandler();
   const oid = req.session.id;
-  const accessToken = getAccessTokenBySessionId(oid || '');
+  const accessToken = await getAccessTokenBySessionId(oid || '');
 
   if (oid && accessToken) {
 

--- a/src/server/routes/authentication.routes.ts
+++ b/src/server/routes/authentication.routes.ts
@@ -343,7 +343,7 @@ function getAuthCode(
 
 function setAccessTokenBySessionId(sessionId: string, response: AuthenticationResult): void {
   if(response.account) {
-    userSessions.set(sessionId, { oid: response.uniqueId, account: response.account }); // Change the renewAt to 1800000
+    userSessions.set(sessionId, { oid: response.uniqueId, account: response.account });
   }
 }
 

--- a/src/server/routes/authentication.routes.ts
+++ b/src/server/routes/authentication.routes.ts
@@ -1,4 +1,5 @@
 import {
+  AccountInfo,
   AuthenticationResult,
   AuthorizationUrlRequest,
   ConfidentialClientApplication,
@@ -50,11 +51,11 @@ const confidentialClientConfig: Configuration = {
       piiLoggingEnabled: false,
       logLevel: LogLevel.Warning,
     },
-  },
+  }
 };
 
 // Session
-type UserSession = { oid: string, accessToken: string, expiresAt: number };
+type UserSession = { oid: string, account: AccountInfo };
 const userSessions = new Map<string, UserSession>();
 
 // Initialize MSAL Node
@@ -76,15 +77,29 @@ const redirects = {
 
 const authenticationRouter: Router = Router();
 
-export function getAccessTokenBySessionId(sessionId: string): string {
+export async function getAccessTokenBySessionId(sessionId: string): Promise<string> {
   const sessionToken = userSessions.get(sessionId);
-  return sessionToken && sessionToken.expiresAt > +new Date()/1000 ? sessionToken.accessToken : '';
+  if(sessionToken) {
+    try {
+      return (await confidentialClientApplication.acquireTokenSilent({
+        account: sessionToken.account,
+        scopes: [],
+      }))?.idToken ?? '';
+    } catch (error: any) {
+      // This will fail if we don't have the token cached but there will be a 401 and a redirect to b2c
+      getAppInsightsClient().trackException({
+        severity: SeverityLevel.Information,
+        exception: error
+      });
+    }
+  }
+  return '';
 }
 
 
 //#region Routes
-authenticationRouter.head(`${ENVIRONMENT.BASE_PATH}/session`, (req, res) => {
-  const authenticated = req.session.id && getAccessTokenBySessionId(req.session.id);
+authenticationRouter.head(`${ENVIRONMENT.BASE_PATH}/session`, async (req, res) => {
+  const authenticated = req.session.id && await getAccessTokenBySessionId(req.session.id);
   if (authenticated) {
     getAppInsightsClient().trackTrace({
       severity: SeverityLevel.Information,
@@ -327,7 +342,9 @@ function getAuthCode(
 };
 
 function setAccessTokenBySessionId(sessionId: string, response: AuthenticationResult): void {
-  userSessions.set(sessionId, { oid: response.uniqueId, accessToken: response.idToken, expiresAt: (response.idTokenClaims as any).exp ?? Math.floor(+new Date()/1000) + 3600 });
+  if(response.account) {
+    userSessions.set(sessionId, { oid: response.uniqueId, account: response.account }); // Change the renewAt to 1800000
+  }
 }
 
 function deleteAccessTokenBySessionId(sessionId: string): void {

--- a/src/server/routes/file-upload.routes.ts
+++ b/src/server/routes/file-upload.routes.ts
@@ -82,7 +82,7 @@ async function uploadFile(url: string, file: any): Promise<void> {
 }
 
 fileUploadRouter.post(`${ENVIRONMENT.BASE_PATH}/upload`, upload.single('file'), async (req, res) => {
-  const accessToken = getAccessTokenBySessionId(req.session.id);
+  const accessToken = await getAccessTokenBySessionId(req.session.id);
   const file = req.file;
   const reqBody = req.body;
 

--- a/src/server/routes/pdf-generator.routes.ts
+++ b/src/server/routes/pdf-generator.routes.ts
@@ -8,12 +8,12 @@ import { getAccessTokenBySessionId } from './authentication.routes';
 const pdfRouter = express.Router();
 
 // Generate PDF endpoint
-pdfRouter.get(`${ENVIRONMENT.BASE_PATH}/exports/:innovationId/pdf`, (req, res) => {
+pdfRouter.get(`${ENVIRONMENT.BASE_PATH}/exports/:innovationId/pdf`, async (req, res) => {
 
   try {
 
     const innovationId = req.params.innovationId;
-    const accessToken = getAccessTokenBySessionId(req.session.id);
+    const accessToken = await getAccessTokenBySessionId(req.session.id);
     const config = { 
       headers: { 
         Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
Add ability to seamlessly renew session if possible:
- leverage MSAL for the session reload using the token
- if it fails, missing the account in authentication store, intercept the 401 and reload page forcing a reload

The fail condition can happen when service restarts (auto scale/new deploy)