### PR TITLE
Create user from different contexts as admin

### DIFF
--- a/src/modules/feature-modules/admin/pages/organisations/organisation-unit-info/organisation-unit-info.component.html
+++ b/src/modules/feature-modules/admin/pages/organisations/organisation-unit-info/organisation-unit-info.component.html
@@ -45,9 +45,8 @@
         <h2 class="nhsuk-heading-l nhsuk-u-margin-0 nhsuk-u-padding-bottom-3">Users</h2>
         <p class="nhsuk-body-m">{{ 'features.admin.organisation_unit.users' | pluralTranslate: usersList.getTotalRowsNumber() | translate:  { count: usersList.getTotalRowsNumber() } }}</p>
 
-        <!-- TODO: In another US -->
         <div class="nhsuk-action-link nhsuk-u-margin-top-5 nhsuk-u-margin-bottom-5">
-          <a class="nhsuk-action-link__link" routerLink="user/edit">
+          <a class="nhsuk-action-link__link" routerLink="/admin/users/new" [queryParams]="{ organisationId, unitId: organisationUnitId }">
             <theme-svg-icon type="action"></theme-svg-icon>
             <span class="nhsuk-action-link__text">Add user</span>
           </a>

--- a/src/modules/feature-modules/admin/pages/users/user-find.component.html
+++ b/src/modules/feature-modules/admin/pages/users/user-find.component.html
@@ -1,5 +1,12 @@
 <theme-content-wrapper [status]="pageStatus">
 
+  <div class="nhsuk-action-link nhsuk-u-margin-bottom-5">
+    <a class="nhsuk-action-link__link" routerLink="/admin/users/new">
+      <theme-svg-icon type="action"></theme-svg-icon>
+      <span class="nhsuk-action-link__text">Add new user</span>
+    </a>
+  </div>
+
   <p> Find a specific user by providing an email address </p>
 
   <div class="nhsuk-grid-row">
@@ -21,8 +28,6 @@
         </div>
 
       </form>
-
-      <button routerLink="/admin/users/new" class="nhsuk-button nhsuk-u-margin-top-3">Add new user</button>
 
     </div>
 

--- a/src/modules/feature-modules/admin/pages/users/user-new.component.html
+++ b/src/modules/feature-modules/admin/pages/users/user-new.component.html
@@ -15,7 +15,7 @@
             <dt class="nhsuk-summary-list__key">{{ item.label }}</dt>
             <dd class="nhsuk-summary-list__value text-pre-wrap">{{ item.value }}</dd>
             <dd class="nhsuk-summary-list__actions">
-              <a href="javascript:;" (click)="onGotoStep(item.editStepNumber || 1)">Change<span class="nhsuk-u-visually-hidden">{{ item.label | lowercase }}</span></a>
+              <a *ngIf="item.editStepNumber" href="javascript:;" (click)="onGotoStep(item.editStepNumber)">Change<span class="nhsuk-u-visually-hidden">{{ item.label | lowercase }}</span></a>
             </dd>
           </div>
         </dl>
@@ -23,7 +23,7 @@
         <button [disabled]="!submitButton.isActive" class="nhsuk-button" (click)="onSubmitWizard()">{{ submitButton.label }}</button>
 
         <div>
-          <a routerLink="/admin/users">Cancel</a>
+          <a href="javascript:;" (click)="goBackOrCancel()">Cancel</a>
         </div>
 
       </ng-container>
@@ -57,7 +57,7 @@
         <button routerLink="/admin/users/{{ user.id }}" class="nhsuk-button">Go to user details</button>
 
         <div>
-          <a routerLink="/admin/users">Cancel</a>
+          <a href="javascript:;" (click)="goBackOrCancel()">Cancel</a>
         </div>
 
       </ng-container>

--- a/src/modules/feature-modules/admin/pages/users/user-new.config.ts
+++ b/src/modules/feature-modules/admin/pages/users/user-new.config.ts
@@ -1,200 +1,212 @@
+import { AppInjector } from '@modules/core';
+
 import { UserRoleEnum } from '@app/base/enums';
-import { FormEngineModel, WizardEngineModel, WizardSummaryType } from '@modules/shared/forms';
+
+import { FormEngineModel, WizardEngineModel, WizardStepType, WizardSummaryType } from '@modules/shared/forms';
+import { AuthenticationStore } from '@modules/stores';
+
+// Labels.
+const stepsLabels = {
+  l1: { label: "What is the new user's email?" },
+  l2: { label: 'What is the name of the new user?', description: 'Enter the first name and surname. This is how their name will appear on the service.' },
+  l3: { label: 'What is their role?' },
+  l4: { label: 'Which organisation is the user associated to?' },
+  l5: { label: 'Which unit is the user associated to?' }
+};
 
 
 // Types.
-type InboundPayloadType = {
-  organisationsList: {
-    id: string,
-    name: string,
-    units: {
-      id: string,
-      name: string
-    }[]
-  }[],
-};
+type Organisation = { id: string; name: string; units: { id: string; name: string; }[] };
 
-type StepPayloadType = {
-  email: string,
-  name: string,
-  role: null | UserRoleEnum.QUALIFYING_ACCESSOR | UserRoleEnum.ACCESSOR | UserRoleEnum.ASSESSMENT | UserRoleEnum.ADMIN,
-  organisationId?: null | string, // Only for QA, A
-  unitIds?: null | string[], // Only for A
-  organisationsList: {
-    id: string,
-    name: string,
-    units: {
-      id: string,
-      name: string
-    }[]
-  }[]
-};
+type CreateUserInBaseInbound = { contextType: 'BASE', organisations: Organisation[] }
+type CreateUserInUnitInbound = { contextType: 'UNIT', organisations: Organisation[], organisationId: string, unitIds: string[] }
+type CreateUserInTeamInbound = { contextType: 'TEAM', role: UserRoleEnum.ASSESSMENT | UserRoleEnum.ADMIN };
+type InboundPayloadType = CreateUserInBaseInbound | CreateUserInUnitInbound | CreateUserInTeamInbound;
 
-export type OutboundPayloadType = {
-  email: string,
-  name: string,
-  role: null | UserRoleEnum.QUALIFYING_ACCESSOR | UserRoleEnum.ACCESSOR | UserRoleEnum.ASSESSMENT | UserRoleEnum.ADMIN,
-  organisationId?: null | string,
-  unitIds?: null | string[],
-};
+type LogicFieldsType = {
+  contextType: 'BASE' | 'UNIT' | 'TEAM';
+  organisations?: Organisation[];
+}
+type QuestionFieldsType = {
+  email?: string;
+  name?: string;
+  role?: UserRoleEnum.QUALIFYING_ACCESSOR | UserRoleEnum.ACCESSOR | UserRoleEnum.ASSESSMENT | UserRoleEnum.ADMIN;
+  organisationId?: string;
+  unitIds?: string[];
+}
+type StepPayloadType = LogicFieldsType & QuestionFieldsType;
 
+type CreateRolesType =
+  | { role: UserRoleEnum.ASSESSMENT | UserRoleEnum.ADMIN | UserRoleEnum.ACCESSOR | UserRoleEnum.QUALIFYING_ACCESSOR }
+  | {
+      role: UserRoleEnum.ACCESSOR | UserRoleEnum.QUALIFYING_ACCESSOR;
+      organisationId: string;
+      unitIds: string[];
+    };
+type CreateUserType = { email: string; name: string; } & CreateRolesType;
+export type OutboundPayloadType = CreateUserType;
 
-export const CREATE_NEW_USER_QUESTIONS: WizardEngineModel = new WizardEngineModel({
-  showSummary: true,
+// consts.
+const injector = AppInjector.getInjector();
+const authenticationStore = injector?.get(AuthenticationStore);
+
+const roles = [UserRoleEnum.QUALIFYING_ACCESSOR, UserRoleEnum.ACCESSOR, UserRoleEnum.ASSESSMENT, UserRoleEnum.ADMIN];
+const roleItems = roles.map(r => ({ value: r, label: authenticationStore.getRoleDescription(r) }));
+
+export const WIZARD_CREATE_USER: WizardEngineModel = new WizardEngineModel({
   steps: [
     new FormEngineModel({
-      parameters: [{
-        id: 'email',
-        dataType: 'text',
-        label: `What is the new user's email?`,
-        description: 'Enter an email with a maximum of 100 characters.',
-        validations: {
-          isRequired: [true, 'Email is required'],
-          validEmail: true,
-          maxLength: 100
-        }
-      }]
+      parameters: [
+        {
+          id: 'email',
+          dataType: 'text',
+          label: stepsLabels.l1.label,
+          validations: {
+            isRequired: [true, 'Email is required'],
+            validEmail: true,
+            maxLength: 100,
+          },
+        },
+      ],
     }),
     new FormEngineModel({
-      parameters: [{
-        id: 'name',
-        dataType: 'text',
-        label: 'What is the name of the new user?',
-        description: 'Enter a name with a maximum of 100 characters.',
-        validations: {
-          isRequired: [true, 'Name is required'],
-          maxLength: 100
-        }
-      }]
-    }),
-    new FormEngineModel({
-      parameters: [{
-        id: 'role',
-        dataType: 'radio-group',
-        label: 'What is their role?',
-        validations: { isRequired: [true, 'Choose one role'] },
-        items: [
-          { value: UserRoleEnum.QUALIFYING_ACCESSOR, label: 'Qualifying Accessor' },
-          { value: UserRoleEnum.ACCESSOR, label: 'Accessor' },
-          { value: UserRoleEnum.ASSESSMENT, label: 'Needs assessor' },
-          { value: UserRoleEnum.ADMIN, label: 'Administrator' }
-        ]
-      }]
+      parameters: [
+        {
+          id: 'name',
+          dataType: 'text',
+          label: stepsLabels.l2.label,
+          description: stepsLabels.l2.description,
+          validations: {
+            isRequired: [true, 'Name is required'],
+            maxLength: 100,
+          },
+        },
+      ],
     })
   ],
-  runtimeRules: [(steps: FormEngineModel[], data: StepPayloadType, currentStep: number | 'summary') => runtimeRules(steps, data, currentStep)],
+  showSummary: true,
+  runtimeRules: [(steps: WizardStepType[], currentValues: StepPayloadType) => wizardRuntimeRules(steps, currentValues)],
   inboundParsing: (data: InboundPayloadType) => inboundParsing(data),
   outboundParsing: (data: StepPayloadType) => outboundParsing(data),
-  summaryParsing: (data: StepPayloadType, steps?: FormEngineModel[]) => summaryParsing(data, steps || [])
+  summaryParsing: (data: StepPayloadType) => summaryParsing(data),
 });
 
+function wizardRuntimeRules(steps: WizardStepType[], data: StepPayloadType): void {
 
-function runtimeRules(steps: FormEngineModel[], data: StepPayloadType, currentStep: number | 'summary'): void {
+  steps.splice(2);
 
-  steps.splice(3);
-
-  if (data.role === UserRoleEnum.ASSESSMENT || data.role === UserRoleEnum.ADMIN) {
-
-    data.organisationId = null;
-    data.unitIds = null;
-
-  }
-  else {
-
+  if(data.contextType === 'BASE' || data.contextType === 'UNIT') {
     steps.push(
       new FormEngineModel({
-        parameters: [{
-          id: 'organisationId',
-          dataType: 'radio-group',
-          label: 'Which organisation is the user associated to?',
-          validations: { isRequired: [true, 'Organisation is required'] },
-          items: data !== null && data.organisationsList !== null ? data.organisationsList.map(o => ({ value: o.id, label: o.name })) : []
-        }]
+        parameters: [
+          {
+            id: 'role',
+            dataType: 'radio-group',
+            label: stepsLabels.l3.label,
+            validations: { isRequired: [true, 'Choose one role'] },
+            items: data.contextType === 'BASE' ? roleItems : roleItems.filter(r => r.value === UserRoleEnum.ACCESSOR || r.value === UserRoleEnum.QUALIFYING_ACCESSOR),
+          },
+        ],
+      })
+    );
+  }
+
+  if (data.role === UserRoleEnum.ASSESSMENT || data.role === UserRoleEnum.ADMIN) {
+    data.organisationId = undefined;
+    data.unitIds = undefined;
+  } else if(data.contextType !== 'UNIT'){
+    steps.push(
+      new FormEngineModel({
+        parameters: [
+          {
+            id: 'organisationId',
+            dataType: 'radio-group',
+            label: stepsLabels.l4.label,
+            validations: { isRequired: [true, 'Organisation is required'] },
+            items: (data.organisations ?? []).map((o) => ({
+              value: o.id,
+              label: o.name,
+            })),
+          },
+        ],
       })
     );
 
-    const unitsList = data !== null && data.organisationsList !== null ? data.organisationsList.find(org => org.id === data.organisationId)?.units.map(units => ({ value: units.id, label: units.name })) || [] : [];
+    if (data.organisationId) {
+      const organisation = (data.organisations ?? []).find(o => o.id === data.organisationId);
+      const units = (organisation?.units ?? []).map(u => ({ value: u.id, label: u.name }));
 
-    if (unitsList.length === 1) {
-      data.unitIds = [unitsList[0].value];
+      if (units.length === 1) {
+        data.unitIds = units.map((u) => u.value);
+      } else {
+        steps.push(
+          new FormEngineModel({
+            parameters: [
+              {
+                id: 'unitIds',
+                dataType: 'checkbox-array',
+                label: stepsLabels.l5.label,
+                validations: { isRequired: [true, 'Unit is required'] },
+                items: units.sort((a, b) => a.value.localeCompare(b.value)),
+              },
+            ],
+          })
+        );
+      }
     }
-    else {
-      steps.push(
-        new FormEngineModel({
-          parameters: [{
-            id: 'unitIds',
-            dataType: 'checkbox-array',
-            label: 'Which unit is the user associated to?',
-            validations: { isRequired: [true, 'Unit is required'] },
-            items: unitsList.sort((a, b) => {
-              const x = a.label.toUpperCase();
-              const y = b.label.toUpperCase();
-              return x === y ? 0 : x > y ? 1 : -1;
-              })
-          }]
-        }),
-      );
-    }
-
   }
-
 }
 
 function inboundParsing(data: InboundPayloadType): StepPayloadType {
   return {
-    email: '',
-    name: '',
-    role: null,
-    organisationId: null,
-    unitIds: null,
-    organisationsList: data.organisationsList
+    contextType: data.contextType ?? 'BASE',
+    ...(data.contextType === 'BASE' && { organisations: data.organisations }),
+    ...(data.contextType === 'UNIT' && { organisations: data.organisations, organisationId: data.organisationId, unitIds: data.unitIds }),
+    ...(data.contextType === 'TEAM' && { role: data.role })
   };
 }
 
 function outboundParsing(data: StepPayloadType): OutboundPayloadType {
-  if (data.role === UserRoleEnum.ADMIN || data.role === UserRoleEnum.ASSESSMENT) {
-    return {
-      email: data.email,
-      name: data.name,
-      role: data.role
-    };
-  }
   return {
-    email: data.email,
-    name: data.name,
-    role: data.role,
-    organisationId: data.organisationId,
-    unitIds: data.unitIds
+    name: data.name ?? '',
+    email: data.email ?? '',
+    role: data.role ?? UserRoleEnum.ASSESSMENT, // This can't happen, since role is required.
+    ...((data.role === UserRoleEnum.ACCESSOR || data.role === UserRoleEnum.QUALIFYING_ACCESSOR) && { organisationId: data.organisationId, unitIds: data.unitIds })
   };
 }
 
-function summaryParsing(data: StepPayloadType, steps: FormEngineModel[]): WizardSummaryType[] {
-
+function summaryParsing(data: StepPayloadType): WizardSummaryType[] {
   const toReturn: WizardSummaryType[] = [];
 
+  let editStepNumber = 1;
+
   toReturn.push(
-    { label: 'Name', value: data.name, editStepNumber: 2  },
-    { label: 'Email', value: data.email, editStepNumber: 1  },
+    { label: 'Email', value: data.email, editStepNumber: editStepNumber++ },
+    { label: 'Name', value: data.name, editStepNumber: editStepNumber++ },
   );
 
-  if (data.role === UserRoleEnum.ADMIN || data.role === UserRoleEnum.ASSESSMENT) {
-    toReturn.push(
-      { label: 'Role', value: data.role === UserRoleEnum.ADMIN ? 'Administrator' : 'Needs Assessor'  , editStepNumber: 3 },
-    );
-  }
-  else {
-    const role = data.role === UserRoleEnum.QUALIFYING_ACCESSOR ? 'Qualifying Accessor' : 'Accessor';
+  const role = authenticationStore.getRoleDescription(data.role ?? UserRoleEnum.ASSESSMENT); // Reaching this point role will be defined
 
-    const unitsList = data.organisationsList.find((org) => (org.id === data.organisationId))?.units.map(units => ({ value: units.id, label: units.name })) || [];
-
-    const selectedOrganisationUnits = unitsList?.filter((item) => (data.unitIds?.includes(item.value)));
+  if(data.role === UserRoleEnum.ADMIN || data.role === UserRoleEnum.ASSESSMENT) {
 
     toReturn.push(
-      { label: selectedOrganisationUnits.length > 1 ? 'Roles' : 'Role', value: selectedOrganisationUnits.map(unit => `${role} (${unit.label})`).join('\n'), editStepNumber: unitsList.length > 1 ? 5 : 4 },
+      { label: 'Role', value: role, editStepNumber: data.contextType === 'BASE' ? editStepNumber++ : undefined }
     );
+
+  } else {
+
+    const org = (data.organisations ?? []).find(o => o.id === data.organisationId);
+    const selectedUnits = (org?.units ?? []).filter(u => data.unitIds?.includes(u.id));
+
+    toReturn.push(
+      {
+        label: selectedUnits.length > 1 ? 'Roles' : 'Role',
+        value: selectedUnits.map(u => `${role} (${u.name})`).join('\n'),
+        editStepNumber
+      }
+    );
+
   }
 
   return toReturn;
-
 }
-

--- a/src/modules/feature-modules/admin/pages/users/user-new.config.ts
+++ b/src/modules/feature-modules/admin/pages/users/user-new.config.ts
@@ -7,7 +7,7 @@ import { AuthenticationStore } from '@modules/stores';
 
 // Labels.
 const stepsLabels = {
-  l1: { label: "What is the new user's email?" },
+  l1: { label: "What is the new user's email?", description: 'Enter an email with a maximum of 100 characters.' },
   l2: { label: 'What is the name of the new user?', description: 'Enter the first name and surname. This is how their name will appear on the service.' },
   l3: { label: 'What is their role?' },
   l4: { label: 'Which organisation is the user associated to?' },
@@ -61,6 +61,7 @@ export const WIZARD_CREATE_USER: WizardEngineModel = new WizardEngineModel({
           id: 'email',
           dataType: 'text',
           label: stepsLabels.l1.label,
+          description: stepsLabels.l1.description,
           validations: {
             isRequired: [true, 'Email is required'],
             validEmail: true,

--- a/src/modules/feature-modules/admin/pages/users/user-new.config.ts
+++ b/src/modules/feature-modules/admin/pages/users/user-new.config.ts
@@ -51,7 +51,7 @@ const injector = AppInjector.getInjector();
 const authenticationStore = injector?.get(AuthenticationStore);
 
 const roles = [UserRoleEnum.QUALIFYING_ACCESSOR, UserRoleEnum.ACCESSOR, UserRoleEnum.ASSESSMENT, UserRoleEnum.ADMIN];
-const roleItems = roles.map(r => ({ value: r, label: authenticationStore.getRoleDescription(r) }));
+const roleItems = roles.map(r => ({ value: r, label: authenticationStore?.getRoleDescription(r) }));
 
 export const WIZARD_CREATE_USER: WizardEngineModel = new WizardEngineModel({
   steps: [


### PR DESCRIPTION
- Created a single config to handle the creation of user
- Can be used to:  
    - Create a new user (Base)
    - Create a new user inside a unit (Unit)
    - Create a new user inside a team (Team)
- Updated button from `Add new user` in user find page