### PR TITLE
Fixed title section mismatch / section link url

### DIFF
--- a/src/modules/shared/pages/innovation/tasks/task-details.component.html
+++ b/src/modules/shared/pages/innovation/tasks/task-details.component.html
@@ -35,7 +35,7 @@
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key nhsuk-u-padding-3">Section</dt>
           <dd class="nhsuk-summary-list__value nhsuk-u-padding-3">
-            <a routerLink="/innovator/innovations/{{ innovationId }}/record/sections/{{ task.section }}">
+            <a routerLink="/{{ userUrlBase }}/innovations/{{ innovationId }}/record/sections/{{ task.section }}">
               {{ sectionTitle }}
             </a>
           </dd>

--- a/src/modules/shared/pages/innovation/tasks/task-details.component.ts
+++ b/src/modules/shared/pages/innovation/tasks/task-details.component.ts
@@ -127,9 +127,9 @@ export class PageInnovationTaskDetailsComponent extends CoreComponent implements
       this.sectionTitle = section ? `${section.group.number}.${section.section.number}: ${section.section.title}` : 'Section no longer available';
 
       if (this.tasksIds.length > 1) {
-        this.setPageTitle(`Update section ${section?.group.number}.${section?.section.number} '${section?.group.title}'`, { hint: `${this.taskNumber + 1} of ${this.tasksIds.length}` });
+        this.setPageTitle(`Update section ${section?.group.number}.${section?.section.number} '${section?.section.title}'`, { hint: `${this.taskNumber + 1} of ${this.tasksIds.length}` });
       } else {
-        this.setPageTitle(`Update section ${section?.group.number}.${section?.section.number} '${section?.group.title}'`, { hint: `Task Id: ${this.task.displayId}` });
+        this.setPageTitle(`Update section ${section?.group.number}.${section?.section.number} '${section?.section.title}'`, { hint: `Task Id: ${this.task.displayId}` });
       }
 
       this.stores.context.dismissNotification(this.innovationId, { contextTypes: [NotificationContextTypeEnum.TASK], contextIds: [this.taskId] });


### PR DESCRIPTION
Fixes for Task Details page:
- Fixed title's section mismatch
- Fixed link in the 'Section' field 

![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/4017664/f23d2123-7bd6-43a9-8930-904fadc23858)
