### PR TITLE
fix - redirect after creating new task from 'Innovation Record'

### DIFF
--- a/src/modules/shared/pages/innovation/sections/section-info.component.html
+++ b/src/modules/shared/pages/innovation/sections/section-info.component.html
@@ -48,7 +48,7 @@
           <span class="nhsuk-u-visually-hidden">Information:</span>
           <p *ngIf="isInnovatorType">This section is not visible to others because you changed it to the 'in draft' status. You need to 'confirm section answers' for the section to become visible.</p>
           <p *ngIf="isAccessorType">
-            You cannot see this section because it is in draft.<span *ngIf="innovation.support?.status === 'ENGAGING' || innovation.support?.status === 'FURTHER_INFO_REQUIRED'"> If you need to see this section, create an action or send a message to the innovator asking them to resubmit it.</span>
+            You cannot see this section because it is in draft.<span *ngIf="innovation.support?.status === 'ENGAGING' || innovation.support?.status === 'FURTHER_INFO_REQUIRED'"> If you need to see this section, create a task or send a message to the innovator asking them to resubmit it.</span>
           </p>
         </div>
 

--- a/src/modules/shared/pages/innovation/tasks/task-details.component.ts
+++ b/src/modules/shared/pages/innovation/tasks/task-details.component.ts
@@ -42,7 +42,7 @@ export class PageInnovationTaskDetailsComponent extends CoreComponent implements
     super();
 
     this.innovationId = this.activatedRoute.snapshot.params.innovationId;
-    this.sectionId = this.activatedRoute.snapshot.queryParams.sectionId;
+    this.sectionId = this.activatedRoute.snapshot.queryParams.sectionId ?? this.activatedRoute.snapshot.params.sectionId;
     this.taskId = this.activatedRoute.snapshot.params.taskId;
 
     this.userUrlBase = this.userUrlBasePath();

--- a/src/modules/shared/pages/innovation/tasks/task-details.component.ts
+++ b/src/modules/shared/pages/innovation/tasks/task-details.component.ts
@@ -57,11 +57,6 @@ export class PageInnovationTaskDetailsComponent extends CoreComponent implements
 
 
   ngOnInit(): void {
-    console.log('section id: ')
-    console.log(this.sectionId);
-    console.log('task id: ')
-    console.log(this.taskId)
-
     if (this.sectionId) {
 
       this.innovationsService.getSectionInfo(this.innovationId, this.sectionId, { fields: ['tasks'] }).subscribe(sectionInfo => {

--- a/src/modules/shared/pages/innovation/tasks/task-details.component.ts
+++ b/src/modules/shared/pages/innovation/tasks/task-details.component.ts
@@ -42,7 +42,7 @@ export class PageInnovationTaskDetailsComponent extends CoreComponent implements
     super();
 
     this.innovationId = this.activatedRoute.snapshot.params.innovationId;
-    this.sectionId = this.activatedRoute.snapshot.params.sectionId;
+    this.sectionId = this.activatedRoute.snapshot.queryParams.sectionId;
     this.taskId = this.activatedRoute.snapshot.params.taskId;
 
     this.userUrlBase = this.userUrlBasePath();
@@ -57,6 +57,10 @@ export class PageInnovationTaskDetailsComponent extends CoreComponent implements
 
 
   ngOnInit(): void {
+    console.log('section id: ')
+    console.log(this.sectionId);
+    console.log('task id: ')
+    console.log(this.taskId)
 
     if (this.sectionId) {
 
@@ -76,7 +80,7 @@ export class PageInnovationTaskDetailsComponent extends CoreComponent implements
 
       });
 
-      this.setBackLink('Go back', `${this.stores.authentication.userUrlBasePath()}/innovations/${this.innovationId}/record`);
+      this.setBackLink('Go back', `${this.stores.authentication.userUrlBasePath()}/innovations/${this.innovationId}/record/sections/${this.sectionId}`);
 
     } else if (this.taskId) {
 

--- a/src/modules/shared/pages/innovation/tasks/wizard-task-new/task-new.component.ts
+++ b/src/modules/shared/pages/innovation/tasks/wizard-task-new/task-new.component.ts
@@ -42,6 +42,7 @@ export class PageInnovationTaskNewComponent extends CoreComponent implements OnI
     this.innovationId = this.activatedRoute.snapshot.params.innovationId;
 
     this.sectionId = this.activatedRoute.snapshot.queryParams.section;
+    console.log(this.sectionId);
 
     this.baseUrl = this.stores.authentication.userUrlBasePath();
 
@@ -191,7 +192,7 @@ export class PageInnovationTaskNewComponent extends CoreComponent implements OnI
     this.innovationsService.createAction(this.innovationId, body).subscribe({
       next: response => {
         this.setRedirectAlertSuccess('You have assigned a task', {message: 'The innovator will be notified and it will be added to their to do list.'});
-        this.redirectTo(`${this.taskUrl}/${response.id}`);
+        this.redirectTo(`${this.taskUrl}/${response.id}`, {sectionId: this.sectionId});
       },
       error: () => this.setAlertError('An error occurred when creating an action. Please try again or contact us for further help')
     });

--- a/src/modules/shared/pages/innovation/tasks/wizard-task-new/task-new.component.ts
+++ b/src/modules/shared/pages/innovation/tasks/wizard-task-new/task-new.component.ts
@@ -42,8 +42,7 @@ export class PageInnovationTaskNewComponent extends CoreComponent implements OnI
     this.innovationId = this.activatedRoute.snapshot.params.innovationId;
 
     this.sectionId = this.activatedRoute.snapshot.queryParams.section;
-    console.log(this.sectionId);
-
+    
     this.baseUrl = this.stores.authentication.userUrlBasePath();
 
     this.taskUrl = `/${this.baseUrl}/innovations/${this.innovationId}/tasks`;


### PR DESCRIPTION
- Added queryParam to redirect in new wizard
- updated url to 'Go back' to redirect to in Task Details page
- Fixed copy on draft section which still had 'action', to 'task'