### PR TITLE
bug 45 - Reverted remove deleted user role on task details page

### DIFF
--- a/src/modules/shared/pages/innovation/tasks/task-details.component.html
+++ b/src/modules/shared/pages/innovation/tasks/task-details.component.html
@@ -18,7 +18,7 @@
           <dt class="nhsuk-summary-list__key nhsuk-u-padding-3">Last update</dt>
           <dd class="nhsuk-summary-list__value nhsuk-u-padding-3">
             <p>{{ task.updatedAt | date : ("app.date_formats.long_date" | translate) }}
-              <span>by {{ task.updatedBy.name }}<span *ngIf="task.updatedBy.name !== '[deleted user]'">, {{ task.updatedBy.displayTag}}</span></span>
+              <span>by {{ task.updatedBy.name }}, {{ task.updatedBy.displayTag}}</span>
             </p>
           </dd>
         </div>


### PR DESCRIPTION
- Reverted previous fix which removed the role of a deleted user

![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/4017664/641f6942-3680-4c79-9700-67342f11244e)
