### PR TITLE
update postcode regex to allow half postcode

### DIFF
--- a/src/modules/shared/forms/validators/custom-validators.spec.ts
+++ b/src/modules/shared/forms/validators/custom-validators.spec.ts
@@ -237,5 +237,43 @@ describe('CustomValidators', () => {
 
   })
 
+  describe('postcodeFormatValidator', () => {
+    beforeAll(() => {
+      formControl = new FormControl();
+      validatorFn = CustomValidators.postcodeFormatValidator();
+    });
+
+    it('should return error when control value is null', () => {
+      formControl.setValue(null);
+      validator = validatorFn(formControl);
+      expect(validator).toEqual({ postcodeFormat: true });
+    });
+
+    it('should return error when control value is invalid postcode', () => {
+      formControl.setValue('1234');
+      validator = validatorFn(formControl);
+      expect(validator).toEqual({ postcodeFormat: true });
+    });
+
+    it('should return null when control value is valid postcode SW1W 0NY', () => {
+      formControl.setValue('SW1W 0NY');
+      validator = validatorFn(formControl);
+      expect(validator).toBeNull();
+    });
+
+    it('should return null when control value is valid postcode PO16 7GZ', () => {
+      formControl.setValue('PO16 7GZ');
+      validator = validatorFn(formControl);
+      expect(validator).toBeNull();
+    });
+
+    it('should return null when control value is valid half postcode SW1W', () => {
+      formControl.setValue('SW1W');
+      validator = validatorFn(formControl);
+      expect(validator).toBeNull();
+    });
+
+  })
+
 
 });

--- a/src/modules/shared/forms/validators/custom-validators.ts
+++ b/src/modules/shared/forms/validators/custom-validators.ts
@@ -84,7 +84,7 @@ export class CustomValidators {
   static postcodeFormatValidator(message?: string | null): ValidatorFn {
     return (control: AbstractControl): ValidationErrors | null => {
       return new RegExp(
-        /^(([A-Z][A-HJ-Y]?\d[A-Z\d]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) \d[A-Z]{2}|BFPO \d{1,4}|(KY\d|MSR|VG|AI)[ -]?\d{4}|[A-Z]{2} \d{2}|GE CX|GIR 0A{2}|SAN TA1)$/gmi
+        /^(([A-Z][A-HJ-Y]?\d[A-Z\d]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA)( \d[A-Z]{2}|BFPO \d{1,4}|(KY\d|MSR|VG|AI)[ -]?\d{4}|[A-Z]{2} \d{2}|GE CX|GIR 0A{2}|SAN TA1)?)$/gmi
       ).test(control.value)
         ? null
         : { postcodeFormat: message ? { message } : true };


### PR DESCRIPTION
Updated existing regex so that last part becomes optional
![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/115169817/f2f87842-211b-40ca-b2fd-f21b62ef621b)
