### PR TITLE
bugfix/151122 Admin: After inactivate/activate unit, link and label didn't update 

### DIFF
--- a/src/modules/feature-modules/admin/admin-routing.module.ts
+++ b/src/modules/feature-modules/admin/admin-routing.module.ts
@@ -149,6 +149,7 @@ const routes: Routes = [
                   {
                     path: ':organisationUnitId',
                     resolve: { organisationUnit: OrganisationUnitDataResolver },
+                    runGuardsAndResolvers: 'always',
                     data: { breadcrumb: (data: { organisationUnit: { id: string, name: string, acronym: string } }) => `${data.organisationUnit.name}` },
                     children: [
                       {


### PR DESCRIPTION
- Resolver wasn't updating on redirect, changed update 'always' on admin-routing.module.ts