### PR TITLE
Change querySelector to getElementById

### DIFF
--- a/src/modules/feature-modules/assessment/pages/innovation/assessment/assessment-edit.component.html
+++ b/src/modules/feature-modules/assessment/pages/innovation/assessment/assessment-edit.component.html
@@ -14,7 +14,7 @@
 
         <div class="full-width-section nhsuk-u-padding-top-5" [ngClass]="{'bg-color-white': (i % 2)}">
           <h2 *ngIf="section.title" class="nhsuk-heading-l nhsuk-u-margin-bottom-0">{{ section.title }}</h2>
-          <theme-form-engine [parameters]="section.parameters" [values]="form.data" (formChanges)="onFormChange()"></theme-form-engine>
+          <theme-form-engine formId="assessmentForm" [parameters]="section.parameters" [values]="form.data" (formChanges)="onFormChange()"></theme-form-engine>
         </div>
 
       </ng-container>

--- a/src/modules/shared/forms/engine/form-engine.component.ts
+++ b/src/modules/shared/forms/engine/form-engine.component.ts
@@ -99,7 +99,7 @@ export class FormEngineComponent implements OnInit, OnChanges, OnDestroy {
     // To avoid missing vital information for SR, position the focus at the top of newly generated content
     if (isPlatformBrowser(this.platformId) && this.onlyOneField) {
       setTimeout(() => {
-        const h = document.querySelector(`#${this.formId}`) as HTMLFormElement;
+        const h = document.getElementById(this.formId) as HTMLFormElement;
         if (h) {
           h.setAttribute('tabIndex', '-1');
           h.focus();


### PR DESCRIPTION
We are allowed to use IDs that start with a digit in our HTML5 documents, but querySelector method uses CSS3 selectors for querying the DOM and CSS3 doesn't support ID selectors that start with a digit.

For more details: https://stackoverflow.com/questions/37270787/uncaught-syntaxerror-failed-to-execute-queryselector-on-document