### PR TITLE
Removed lowercase pipe

### DIFF
--- a/src/modules/theme/components/header/breadcrumbs-bar.component.html
+++ b/src/modules/theme/components/header/breadcrumbs-bar.component.html
@@ -9,7 +9,7 @@
     </ol>
     <p class="nhsuk-breadcrumb__back">
       <a class="nhsuk-breadcrumb__backlink" [routerLink]="backToItem.url">
-        <span class="nhsuk-u-visually-hidden">Back to &nbsp;</span>{{ backToItem.label | lowercase }}
+        <span class="nhsuk-u-visually-hidden">Back to &nbsp;</span>{{ backToItem.label }}
       </a>
     </p>
   </div>


### PR DESCRIPTION
- Fix for bug 146991, where breadcrumbs in mobile where lowercase
![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/4017664/40f25147-fa92-48dc-9818-729d1aa6b1b7)
