### PR TITLE
style: change copy from admin category

### DIFF
--- a/src/app/config/translations/en.ts
+++ b/src/app/config/translations/en.ts
@@ -510,9 +510,9 @@ export const locale = {
             },
 
             ADMIN: {
-              INNOVATOR: { title: 'Your account' },
-              QUALIFYING_ACCESSOR: { title: 'Your account' },
-              ACCESSOR: { title: 'Your account' }
+              INNOVATOR: { title: 'Administrator updates' },
+              QUALIFYING_ACCESSOR: { title: 'Administrator updates' },
+              ACCESSOR: { title: 'Administrator updates' }
             },
 
             AUTOMATIC: {


### PR DESCRIPTION
Changed the copy from `ADMIN` category from `Your account` to `Administrator updates`.