### PR TITLE
Bugfix/157532-messages-search-disapperar-on-stopped-sharing-inno-w-no-results

### DIFF
--- a/src/modules/shared/pages/innovation/messages/threads-list.component.html
+++ b/src/modules/shared/pages/innovation/messages/threads-list.component.html
@@ -38,7 +38,7 @@
       </ng-container>
     </div>
 
-    <div *ngIf="canCreateThread || (!canCreateThread && tableList.getTotalRowsNumber() > 0)" class="nhsuk-grid-column-full">
+    <div class="nhsuk-grid-column-full">
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-one-half">
           <form [formGroup]="form">


### PR DESCRIPTION
- Removed unnecessary ngIf on div, as everyone is able to access the search for messages, if 'isInnovationSubmitted'.