### PR TITLE
Bugfix/158542 all sections not showing docs for section in draft

### DIFF
--- a/src/modules/shared/pages/innovation/sections/section-info-all.component.html
+++ b/src/modules/shared/pages/innovation/sections/section-info-all.component.html
@@ -40,7 +40,7 @@
                 <div class="nhsuk-u-margin-top-0 font-color-secondary">
                   <span class="nhsuk-u-visually-hidden">Information: </span>
                   <p class="d-flex nhsuk-u-margin-0">
-                    <ng-container [ngSwitch]="sectionData.sectionInfo?.status?.id">
+                    <ng-container [ngSwitch]="sectionData.sectionInfo.status.id">
                       <ng-container *ngSwitchCase="'NOT_STARTED'">
                         <theme-svg-icon type="error" customColor="grey"></theme-svg-icon>
                         <span class="nhsuk-u-margin-right-2"></span>
@@ -66,11 +66,11 @@
                           <theme-svg-icon type="success"></theme-svg-icon>
                           <span class="nhsuk-u-margin-right-2"></span>
                           <span class="nhsuk-u-font-size-16 nhsuk-u-margin-bottom-4">
-                            This section was last submitted by {{ sectionData.sectionInfo?.submittedBy?.name }}
+                            This section was last submitted by {{ sectionData.sectionInfo.submittedBy?.name }}
                             <ng-container *ngIf="sectionData.sectionInfo?.submittedBy?.displayTag !== undefined"
-                              >({{ sectionData.sectionInfo?.submittedBy?.displayTag }})</ng-container
+                              >({{ sectionData.sectionInfo.submittedBy?.displayTag }})</ng-container
                             >
-                            on {{ sectionData.sectionInfo?.date | date: ("app.date_formats.long_date" | translate) }}.
+                            on {{ sectionData.sectionInfo.date | date: ("app.date_formats.long_date" | translate) }}.
                           </span>
                         </ng-container>
                       </ng-container>
@@ -84,12 +84,12 @@
                       type="{{ 'shared.catalog.innovation.task_status.OPEN.cssColorClass' | translate }}"
                       label="{{ 'shared.catalog.innovation.task_status.OPEN.name' | translate }}"
                     ></theme-tag>
-                    This section has {{ sectionData.sectionInfo?.openTasksCount }} {{ "dictionary.task" | pluralTranslate: sectionData.sectionInfo?.openTasksCount | translate }} to
-                    do. <a routerLink="/{{ baseUrl }}/record/sections/{{ sectionData.sectionInfo?.id }}/tasks">View tasks.</a>
+                    This section has {{ sectionData.sectionInfo.openTasksCount }} {{ "dictionary.task" | pluralTranslate: sectionData.sectionInfo.openTasksCount | translate }} to
+                    do. <a routerLink="/{{ baseUrl }}/record/sections/{{ sectionData.sectionInfo.id }}/tasks">View tasks.</a>
                   </p>
                 </div>
 
-                <shared-innovation-summary [sectionData]="getSectionSummaryData(section.id)" />
+                <shared-innovation-summary [sectionData]="sectionData" />
               </ng-container>
             </ng-container>
           </div>

--- a/src/modules/shared/pages/innovation/sections/section-info-all.component.html
+++ b/src/modules/shared/pages/innovation/sections/section-info-all.component.html
@@ -89,19 +89,7 @@
                   </p>
                 </div>
 
-                <ng-container *ngIf="(isAccessorType || isAssessmentType) && sectionData.sectionInfo?.status?.id === 'DRAFT'; else summaryComponent">
-                  <div class="nhsuk-inset-text nhsuk-u-margin-top-2 nhsuk-u-padding-top-0 nhsuk-u-padding-bottom-0">
-                    <span class="nhsuk-u-visually-hidden">Information:</span>
-                    <p>
-                      You cannot see this section because it is in draft. If you need to see this section, create a task or send a message to the innovator asking them to resubmit
-                      it.
-                    </p>
-                  </div>
-                </ng-container>
-
-                <ng-template #summaryComponent>
-                  <shared-innovation-summary [sectionData]="getSectionSummaryData(section.id)" />
-                </ng-template>
+                <shared-innovation-summary [sectionData]="getSectionSummaryData(section.id)" />
               </ng-container>
             </ng-container>
           </div>

--- a/src/modules/shared/pages/innovation/sections/section-info-all.component.ts
+++ b/src/modules/shared/pages/innovation/sections/section-info-all.component.ts
@@ -206,7 +206,7 @@ export class PageInnovationAllSectionsInfoComponent extends CoreComponent implem
           return document.context.id === responseItem.section.section;
         });
 
-        this.allSectionsData[sectionInfo.id as InnovationSections] = {
+        this.allSectionsData[sectionInfo.id as InnovationSectionEnum] = {
           evidencesList: evidencesList,
           sectionInfo: sectionInfo,
           summaryList: summaryList,

--- a/src/modules/shared/pages/innovation/sections/section-info-all.component.ts
+++ b/src/modules/shared/pages/innovation/sections/section-info-all.component.ts
@@ -263,8 +263,4 @@ export class PageInnovationAllSectionsInfoComponent extends CoreComponent implem
 
     this.allSectionsSubmitted = this.sections.submitted === this.sections.progressBar.length;
   }
-
-  getSectionSummaryData(section: string): SectionSummaryInputData {
-    return this.allSectionsData[section as InnovationSections]!;
-  }
 }

--- a/src/modules/shared/pages/innovation/sections/section-info-all.component.ts
+++ b/src/modules/shared/pages/innovation/sections/section-info-all.component.ts
@@ -7,7 +7,7 @@ import {
   InnovationDocumentsService
 } from '@modules/shared/services/innovation-documents.service';
 import { ContextInnovationType } from '@modules/stores';
-import { InnovationStatusEnum } from '@modules/stores/innovation';
+import { InnovationSectionEnum, InnovationStatusEnum } from '@modules/stores/innovation';
 import { InnovationSections } from '@modules/stores/innovation/innovation-record/202209/catalog.types';
 import { INNOVATION_SECTIONS } from '@modules/stores/innovation/innovation-record/202304/main.config';
 import { getAllSectionsList } from '@modules/stores/innovation/innovation-record/ir-versions.config';
@@ -61,11 +61,11 @@ export class PageInnovationAllSectionsInfoComponent extends CoreComponent implem
   allSectionsSubmitted = false;
 
   allSectionsData: {
-    [k in InnovationSections as string]?: {
-      sectionInfo?: SectionInfoType;
-      summaryList?: WizardSummaryType[];
-      evidencesList?: WizardSummaryType[];
-      documentsList?: InnovationDocumentsListOutDTO['data'];
+    [key in InnovationSectionEnum]?: {
+      sectionInfo: SectionInfoType;
+      summaryList: WizardSummaryType[];
+      evidencesList: WizardSummaryType[];
+      documentsList: InnovationDocumentsListOutDTO['data'];
     };
   } = {};
 
@@ -200,16 +200,18 @@ export class PageInnovationAllSectionsInfoComponent extends CoreComponent implem
           const data = sectionInfo.wizard.runSummaryParsing();
           summaryList = data.filter(item => !item.evidenceId);
           evidencesList = data.filter(item => item.evidenceId);
-          documentsList = documentsResponse.data.filter(
-            document => document.context.id === responseItem.section.section
-          );
         }
 
-        this.allSectionsData[sectionInfo.id] = {};
-        this.allSectionsData[sectionInfo.id]!.evidencesList = evidencesList;
-        this.allSectionsData[sectionInfo.id]!.sectionInfo = sectionInfo;
-        this.allSectionsData[sectionInfo.id]!.summaryList = summaryList;
-        this.allSectionsData[sectionInfo.id]!.documentsList = documentsList;
+        documentsList = documentsResponse.data.filter(document => {
+          return document.context.id === responseItem.section.section;
+        });
+
+        this.allSectionsData[sectionInfo.id as InnovationSections] = {
+          evidencesList: evidencesList,
+          sectionInfo: sectionInfo,
+          summaryList: summaryList,
+          documentsList: documentsList
+        };
       }
 
       this.setSectionsStatistics(summary);
@@ -263,11 +265,6 @@ export class PageInnovationAllSectionsInfoComponent extends CoreComponent implem
   }
 
   getSectionSummaryData(section: string): SectionSummaryInputData {
-    return {
-      sectionInfo: this.allSectionsData[section]!.sectionInfo!,
-      summaryList: this.allSectionsData[section]!.summaryList!,
-      evidencesList: this.allSectionsData[section]!.evidencesList!,
-      documentsList: this.allSectionsData[section]!.documentsList!
-    };
+    return this.allSectionsData[section as InnovationSections]!;
   }
 }

--- a/src/modules/shared/pages/innovation/sections/section-info.component.html
+++ b/src/modules/shared/pages/innovation/sections/section-info.component.html
@@ -64,29 +64,20 @@
         <button type="button" routerLink="edit" class="nhsuk-button nhsuk-u-margin-right-3">Start now</button>
       </ng-container>
 
-      <ng-container *ngIf="summaryList.length > 0">
+      <ng-container *ngIf="sectionSummaryData.summaryList.length > 0">
         <h2>Questions and answers</h2>
       </ng-container>
 
       <ng-container *ngIf="pageStatus === 'READY'">
-        <ng-container *ngIf="(isAccessorType || isAssessmentType) && sectionInfo.status.id === 'DRAFT'; else summaryComponent">
-          <div class="nhsuk-inset-text nhsuk-u-margin-top-2 nhsuk-u-padding-top-0 nhsuk-u-padding-bottom-0">
-            <span class="nhsuk-u-visually-hidden">Information:</span>
-            <p>You cannot see this section because it is in draft. If you need to see this section, create a task or send a message to the innovator asking them to resubmit it.</p>
-          </div>
-        </ng-container>
-
-        <ng-template #summaryComponent>
-          <shared-innovation-summary [sectionData]="getSectionSummaryData()" />
-        </ng-template>
+        <shared-innovation-summary [sectionData]="this.sectionSummaryData" />
       </ng-container>
 
       <ng-container *ngIf="sectionInfo.hasEvidences">
         <h2 class="nhsuk-u-margin-top-4">Evidence</h2>
         <button *ngIf="isInnovatorType" routerLink="evidences/new" class="nhsuk-button nhsuk-button--secondary">Add evidence</button>
-        <p *ngIf="evidencesList.length === 0">There are no evidences on this section.</p>
-        <dl *ngIf="evidencesList.length > 0" class="nhsuk-summary-list">
-          <div *ngFor="let item of evidencesList" class="nhsuk-summary-list__row">
+        <p *ngIf="sectionSummaryData.evidencesList.length === 0">There are no evidences on this section.</p>
+        <dl *ngIf="sectionSummaryData.evidencesList.length > 0" class="nhsuk-summary-list">
+          <div *ngFor="let item of sectionSummaryData.evidencesList" class="nhsuk-summary-list__row">
             <dt class="nhsuk-summary-list__key">{{ item.label }}</dt>
             <dd class="nhsuk-summary-list__value text-pre-wrap">{{ item.value }}</dd>
             <dd class="nhsuk-summary-list__actions">
@@ -101,9 +92,9 @@
         <button *ngIf="isInnovatorType" routerLink="/{{ baseUrl }}/documents/new" [queryParams]="{ sectionId: sectionInfo.id }" class="nhsuk-button nhsuk-button--secondary">
           Upload a new document
         </button>
-        <p *ngIf="documentsList.length === 0">There are no documents uploaded to this section.</p>
-        <dl *ngIf="documentsList.length > 0" class="nhsuk-summary-list">
-          <div *ngFor="let document of documentsList; let i = index" class="nhsuk-summary-list__row">
+        <p *ngIf="sectionSummaryData.documentsList.length === 0">There are no documents uploaded to this section.</p>
+        <dl *ngIf="sectionSummaryData.documentsList.length > 0" class="nhsuk-summary-list">
+          <div *ngFor="let document of sectionSummaryData.documentsList; let i = index" class="nhsuk-summary-list__row">
             <dt class="nhsuk-summary-list__key">Document {{ i + 1 }}</dt>
             <dd class="nhsuk-summary-list__value text-pre-wrap">
               <a href="{{ document.file.url }}" attr.aria-label="Download {{ document.name }} file"

--- a/src/modules/shared/pages/innovation/sections/section-info.component.html
+++ b/src/modules/shared/pages/innovation/sections/section-info.component.html
@@ -3,10 +3,10 @@
     <div class="nhsuk-grid-column-full">
       <div class="nhsuk-u-margin-top-0">
         <span class="nhsuk-u-visually-hidden">Information: </span>
-        <ng-container [ngSwitch]="sectionInfo.status.id">
+        <ng-container [ngSwitch]="this.sectionSummaryData.sectionInfo.status.id">
           <p class="d-flex">
             <ng-container *ngSwitchCase="'NOT_STARTED'">
-              <theme-svg-icon type="error"></theme-svg-icon>
+              <theme-svg-icon type="error" customColor="grey"></theme-svg-icon>
               <span class="nhsuk-u-margin-right-2"></span>
               <span>This section has not been started yet.</span>
             </ng-container>
@@ -36,11 +36,12 @@
             </ng-container>
 
             <ng-container *ngSwitchCase="'SUBMITTED'">
-              <ng-container *ngIf="sectionInfo.date !== '' && sectionInfo.submittedBy !== null">
+              <ng-container *ngIf="this.sectionSummaryData.sectionInfo.date !== '' && this.sectionSummaryData.sectionInfo.submittedBy !== null">
                 <theme-svg-icon type="success"></theme-svg-icon>
                 <span class="nhsuk-u-margin-right-2"></span>
                 <span>
-                  This section was last submitted by {{ sectionInfo.submittedBy.name }} on {{ sectionInfo.date | date: ("app.date_formats.long_date" | translate) }}.
+                  This section was last submitted by {{ this.sectionSummaryData.sectionInfo.submittedBy.name }} on
+                  {{ this.sectionSummaryData.sectionInfo.date | date: ("app.date_formats.long_date" | translate) }}.
                   <span class="d-inline-block" *ngIf="isInnovatorType">You can update this section at any time.</span>
                 </span>
               </ng-container>
@@ -49,18 +50,19 @@
         </ng-container>
       </div>
 
-      <div *ngIf="isInnovatorType && sectionInfo.openTasksCount > 0" class="nhsuk-u-margin-bottom-5">
+      <div *ngIf="isInnovatorType && this.sectionSummaryData.sectionInfo.openTasksCount > 0" class="nhsuk-u-margin-bottom-5">
         <p>
           <theme-tag
             type="{{ 'shared.catalog.innovation.task_status.OPEN.cssColorClass' | translate }}"
             label="{{ 'shared.catalog.innovation.task_status.OPEN.name' | translate }}"
           ></theme-tag>
-          This section has {{ sectionInfo.openTasksCount }} {{ "dictionary.task" | pluralTranslate: sectionInfo.openTasksCount | translate }} to do.
-          <a routerLink="/{{ baseUrl }}/record/sections/{{ sectionInfo.id }}/tasks">View tasks.</a>
+          This section has {{ this.sectionSummaryData.sectionInfo.openTasksCount }}
+          {{ "dictionary.task" | pluralTranslate: this.sectionSummaryData.sectionInfo.openTasksCount | translate }} to do.
+          <a routerLink="/{{ baseUrl }}/record/sections/{{ this.sectionSummaryData.sectionInfo.id }}/tasks">View tasks.</a>
         </p>
       </div>
 
-      <ng-container *ngIf="isInnovatorType && sectionInfo.isNotStarted">
+      <ng-container *ngIf="isInnovatorType && this.sectionSummaryData.sectionInfo.isNotStarted">
         <button type="button" routerLink="edit" class="nhsuk-button nhsuk-u-margin-right-3">Start now</button>
       </ng-container>
 
@@ -72,7 +74,7 @@
         <shared-innovation-summary [sectionData]="this.sectionSummaryData" />
       </ng-container>
 
-      <ng-container *ngIf="sectionInfo.hasEvidences">
+      <ng-container *ngIf="this.sectionSummaryData.sectionInfo.hasEvidences">
         <h2 class="nhsuk-u-margin-top-4">Evidence</h2>
         <button *ngIf="isInnovatorType" routerLink="evidences/new" class="nhsuk-button nhsuk-button--secondary">Add evidence</button>
         <p *ngIf="sectionSummaryData.evidencesList.length === 0">There are no evidences on this section.</p>
@@ -89,7 +91,12 @@
 
       <ng-container *ngIf="shouldShowDocuments">
         <h2 class="nhsuk-u-margin-top-4">Documents</h2>
-        <button *ngIf="isInnovatorType" routerLink="/{{ baseUrl }}/documents/new" [queryParams]="{ sectionId: sectionInfo.id }" class="nhsuk-button nhsuk-button--secondary">
+        <button
+          *ngIf="isInnovatorType"
+          routerLink="/{{ baseUrl }}/documents/new"
+          [queryParams]="{ sectionId: this.sectionSummaryData.sectionInfo.id }"
+          class="nhsuk-button nhsuk-button--secondary"
+        >
           Upload a new document
         </button>
         <p *ngIf="sectionSummaryData.documentsList.length === 0">There are no documents uploaded to this section.</p>
@@ -110,7 +117,9 @@
       </ng-container>
 
       <div *ngIf="isInnovatorType">
-        <button *ngIf="sectionInfo.submitButton.show" (click)="onSubmitSection()" class="nhsuk-button nhsuk-u-margin-top-5">{{ sectionInfo.submitButton.label }}</button>
+        <button *ngIf="this.sectionSummaryData.sectionInfo.submitButton.show" (click)="onSubmitSection()" class="nhsuk-button nhsuk-u-margin-top-5">
+          {{ this.sectionSummaryData.sectionInfo.submitButton.label }}
+        </button>
       </div>
 
       <ng-container
@@ -119,7 +128,11 @@
           (['NEEDS_ASSESSMENT', 'IN_PROGRESS', 'COMPLETE'].includes(innovation.status) && isAssessmentType)
         "
       >
-        <button routerLink="/{{ baseUrl }}/tasks/new" [queryParams]="{ section: sectionInfo.id }" class="nhsuk-button nhsuk-u-margin-top-5 nhsuk-u-margin-right-3">
+        <button
+          routerLink="/{{ baseUrl }}/tasks/new"
+          [queryParams]="{ section: this.sectionSummaryData.sectionInfo.id }"
+          class="nhsuk-button nhsuk-u-margin-top-5 nhsuk-u-margin-right-3"
+        >
           Assign a task for this section
         </button>
       </ng-container>

--- a/src/modules/shared/pages/innovation/sections/section-info.component.ts
+++ b/src/modules/shared/pages/innovation/sections/section-info.component.ts
@@ -64,8 +64,6 @@ export class PageInnovationSectionInfoComponent extends CoreComponent implements
   isAssessmentType: boolean;
   shouldShowDocuments = false;
 
-  sectionInfo: SectionInfoType;
-
   constructor(
     private activatedRoute: ActivatedRoute,
     private innovationDocumentsService: InnovationDocumentsService
@@ -85,21 +83,6 @@ export class PageInnovationSectionInfoComponent extends CoreComponent implements
     this.isInnovatorType = this.stores.authentication.isInnovatorType();
     this.isAccessorType = this.stores.authentication.isAccessorType();
     this.isAssessmentType = this.stores.authentication.isAssessmentType();
-
-    this.sectionInfo = {
-      id: '',
-      nextSectionId: null,
-      title: '',
-      status: { id: 'UNKNOWN', label: '' },
-      submitButton: { show: false, label: 'Confirm section answers' },
-      isNotStarted: false,
-      hasEvidences: false,
-      wizard: new WizardEngineModel({}),
-      allStepsList: {},
-      date: '',
-      submittedBy: null,
-      openTasksCount: 0
-    };
 
     this.sectionSummaryData = {
       sectionInfo: {

--- a/src/modules/shared/pages/innovation/sections/section-info.component.ts
+++ b/src/modules/shared/pages/innovation/sections/section-info.component.ts
@@ -45,9 +45,13 @@ export class PageInnovationSectionInfoComponent extends CoreComponent implements
   sectionSubmittedText: string = '';
 
   sectionsIdsList: string[];
-  summaryList: WizardSummaryType[] = [];
-  evidencesList: WizardSummaryType[] = [];
-  documentsList: InnovationDocumentsListOutDTO['data'] = [];
+
+  sectionSummaryData: {
+    sectionInfo: SectionInfoType;
+    summaryList: WizardSummaryType[];
+    evidencesList: WizardSummaryType[];
+    documentsList: InnovationDocumentsListOutDTO['data'];
+  };
 
   previousSection: null | { id: string; title: string } = null;
   nextSection: null | { id: string; title: string } = null;
@@ -96,6 +100,26 @@ export class PageInnovationSectionInfoComponent extends CoreComponent implements
       submittedBy: null,
       openTasksCount: 0
     };
+
+    this.sectionSummaryData = {
+      sectionInfo: {
+        id: '',
+        nextSectionId: null,
+        title: '',
+        status: { id: 'UNKNOWN', label: '' },
+        submitButton: { show: false, label: 'Confirm section answers' },
+        isNotStarted: false,
+        hasEvidences: false,
+        wizard: new WizardEngineModel({}),
+        allStepsList: {},
+        date: '',
+        submittedBy: null,
+        openTasksCount: 0
+      },
+      summaryList: [],
+      evidencesList: [],
+      documentsList: []
+    };
   }
 
   ngOnInit(): void {
@@ -128,75 +152,85 @@ export class PageInnovationSectionInfoComponent extends CoreComponent implements
 
     const section = this.stores.innovation.getInnovationRecordSection(this.sectionId);
 
-    this.sectionInfo.id = section.id;
-    this.sectionInfo.title = section.title;
-    this.sectionInfo.wizard = section.wizard;
-    this.sectionInfo.allStepsList = section.allStepsList ? section.allStepsList : {};
+    this.sectionSummaryData.sectionInfo.id = section.id;
+    this.sectionSummaryData.sectionInfo.title = section.title;
+    this.sectionSummaryData.sectionInfo.wizard = section.wizard;
+    this.sectionSummaryData.sectionInfo.allStepsList = section.allStepsList ? section.allStepsList : {};
 
     this.shouldShowDocuments =
       this.innovation.status !== InnovationStatusEnum.CREATED ||
       (this.innovation.status === InnovationStatusEnum.CREATED &&
-        innovationSectionsWithFiles.includes(this.sectionInfo.id));
+        innovationSectionsWithFiles.includes(this.sectionSummaryData.sectionInfo.id));
 
     forkJoin([
-      this.stores.innovation.getSectionInfo$(this.innovation.id, this.sectionInfo.id),
+      this.stores.innovation.getSectionInfo$(this.innovation.id, this.sectionSummaryData.sectionInfo.id),
       !this.shouldShowDocuments
         ? of(null)
         : this.innovationDocumentsService.getDocumentList(this.innovation.id, {
             skip: 0,
             take: 100,
             order: { createdAt: 'ASC' },
-            filters: { contextTypes: ['INNOVATION_SECTION'], contextId: this.sectionInfo.id, fields: ['description'] }
+            filters: {
+              contextTypes: ['INNOVATION_SECTION'],
+              contextId: this.sectionSummaryData.sectionInfo.id,
+              fields: ['description']
+            }
           })
     ]).subscribe(([sectionInfo, documents]) => {
-      this.sectionInfo.status = {
+      this.sectionSummaryData.sectionInfo.status = {
         id: sectionInfo.status,
         label: INNOVATION_SECTION_STATUS[sectionInfo.status]?.label || ''
       };
-      this.sectionInfo.isNotStarted = ['NOT_STARTED', 'UNKNOWN'].includes(this.sectionInfo.status.id);
-      this.sectionInfo.date = sectionInfo.submittedAt;
-      this.sectionInfo.submittedBy = sectionInfo.submittedBy;
-      this.sectionInfo.openTasksCount = sectionInfo.tasksIds ? sectionInfo.tasksIds.length : 0;
+      this.sectionSummaryData.sectionInfo.isNotStarted = ['NOT_STARTED', 'UNKNOWN'].includes(
+        this.sectionSummaryData.sectionInfo.status.id
+      );
+      this.sectionSummaryData.sectionInfo.date = sectionInfo.submittedAt;
+      this.sectionSummaryData.sectionInfo.submittedBy = sectionInfo.submittedBy;
+      this.sectionSummaryData.sectionInfo.openTasksCount = sectionInfo.tasksIds ? sectionInfo.tasksIds.length : 0;
 
       if (
         this.stores.authentication.isAccessorType() &&
         this.innovation.status === 'IN_PROGRESS' &&
-        this.sectionInfo.status.id === 'DRAFT'
+        this.sectionSummaryData.sectionInfo.status.id === 'DRAFT'
       ) {
         // If accessor, only view information if section is submitted.
-        this.summaryList = [];
+        this.sectionSummaryData.summaryList = [];
       } else {
         // Special business rule around section 2.2.
-        this.sectionInfo.hasEvidences = !!(
+        this.sectionSummaryData.sectionInfo.hasEvidences = !!(
           section.evidences &&
           sectionInfo.data.hasEvidence &&
           sectionInfo.data.hasEvidence === 'YES'
         );
 
-        this.sectionInfo.wizard.setAnswers(this.sectionInfo.wizard.runInboundParsing(sectionInfo.data)).runRules();
+        this.sectionSummaryData.sectionInfo.wizard
+          .setAnswers(this.sectionSummaryData.sectionInfo.wizard.runInboundParsing(sectionInfo.data))
+          .runRules();
 
-        const validInformation = this.sectionInfo.wizard.validateData();
+        const validInformation = this.sectionSummaryData.sectionInfo.wizard.validateData();
 
-        if (this.sectionInfo.status.id === 'DRAFT' && validInformation.valid) {
-          this.sectionInfo.submitButton.show = true;
+        if (this.sectionSummaryData.sectionInfo.status.id === 'DRAFT' && validInformation.valid) {
+          this.sectionSummaryData.sectionInfo.submitButton.show = true;
           if (
             this.innovation.status !== InnovationStatusEnum.CREATED &&
             this.innovation.status !== InnovationStatusEnum.WAITING_NEEDS_ASSESSMENT
           ) {
-            this.sectionInfo.submitButton.label = 'Submit updates';
+            this.sectionSummaryData.sectionInfo.submitButton.label = 'Submit updates';
           }
         } else {
-          this.sectionInfo.submitButton.show = false;
+          this.sectionSummaryData.sectionInfo.submitButton.show = false;
         }
 
-        const data = this.sectionInfo.wizard.runSummaryParsing();
-        this.summaryList = data.filter(item => !item.evidenceId);
-        this.evidencesList = data.filter(item => item.evidenceId);
+        const data = this.sectionSummaryData.sectionInfo.wizard.runSummaryParsing();
+
+        this.sectionSummaryData.summaryList = data.filter(item => !item.evidenceId);
+
+        this.sectionSummaryData.evidencesList = data.filter(item => item.evidenceId);
       }
 
       this.getPreviousAndNextPagination();
 
-      this.documentsList = documents?.data ?? [];
+      this.sectionSummaryData.documentsList = documents?.data ?? [];
 
       this.setPageStatus('READY');
     });
@@ -233,23 +267,23 @@ export class PageInnovationSectionInfoComponent extends CoreComponent implements
   }
 
   onSubmitSection(): void {
-    this.stores.innovation.submitSections$(this.innovation.id, this.sectionInfo.id).subscribe({
+    this.stores.innovation.submitSections$(this.innovation.id, this.sectionSummaryData.sectionInfo.id).subscribe({
       next: () => {
         if (
           this.innovation.status === InnovationStatusEnum.CREATED ||
           this.innovation.status === InnovationStatusEnum.WAITING_NEEDS_ASSESSMENT
         ) {
-          this.sectionInfo.status = { id: 'SUBMITTED', label: 'Submitted' };
-          this.sectionInfo.submitButton.show = false;
-          this.sectionInfo.nextSectionId = this.getNextSectionId();
+          this.sectionSummaryData.sectionInfo.status = { id: 'SUBMITTED', label: 'Submitted' };
+          this.sectionSummaryData.sectionInfo.submitButton.show = false;
+          this.sectionSummaryData.sectionInfo.nextSectionId = this.getNextSectionId();
           this.setAlertSuccess('Your answers have been confirmed for this section', {
-            message: this.sectionInfo.nextSectionId
+            message: this.sectionSummaryData.sectionInfo.nextSectionId
               ? 'Go to next section or return to the full innovation record'
               : undefined
           });
         } else {
           this.setRedirectAlertSuccess(this.sectionSubmittedText);
-          this.redirectTo(`/${this.baseUrl}/record/sections/${this.sectionInfo.id}/submitted`);
+          this.redirectTo(`/${this.baseUrl}/record/sections/${this.sectionSummaryData.sectionInfo.id}/submitted`);
         }
       },
       error: () => this.setAlertUnknownError()
@@ -257,17 +291,8 @@ export class PageInnovationSectionInfoComponent extends CoreComponent implements
   }
 
   private getNextSectionId(): string | null {
-    const currentSectionIndex = this.sectionsIdsList.indexOf(this.sectionInfo.id);
+    const currentSectionIndex = this.sectionsIdsList.indexOf(this.sectionSummaryData.sectionInfo.id);
 
     return this.sectionsIdsList[currentSectionIndex + 1] || null;
-  }
-
-  getSectionSummaryData(): SectionSummaryInputData {
-    return {
-      sectionInfo: this.sectionInfo,
-      summaryList: this.summaryList,
-      evidencesList: this.evidencesList,
-      documentsList: this.documentsList
-    };
   }
 }

--- a/src/modules/shared/pages/innovation/sections/section-summary.component.html
+++ b/src/modules/shared/pages/innovation/sections/section-summary.component.html
@@ -20,78 +20,89 @@
     </ng-container>
 
     <ng-container *ngIf="!sectionInfo.isNotStarted">
-      <ng-container *ngIf="summaryList.length > 0">
-        <dl class="nhsuk-summary-list nhsuk-u-margin-bottom-0">
-          <ng-container *ngFor="let item of summaryList" class="nhsuk-summary-list__row">
-            <ng-container [ngSwitch]="item.type">
-              <ng-container *ngSwitchCase="'button'">
-                <div *ngIf="isInnovatorType" class="width-max-content">
-                  <dt class="nhsuk-u-margin-top-5">
-                    <a routerLink="edit/{{ item.editStepNumber }}" class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-0">{{ item.label }}</a>
-                  </dt>
-                </div>
-              </ng-container>
-              <ng-container *ngSwitchDefault>
-                <div class="nhsuk-summary-list__row">
-                  <dt class="nhsuk-summary-list__key nhsuk-u-margin-padding-4 nhsuk-u-padding-bottom-4">{{ item.label }}</dt>
-                  <dd class="nhsuk-summary-list__value text-pre-wrap">
-                    <span *ngIf="item.allowHTML" [innerHTML]="item.value"></span>
-                    <span *ngIf="!item.allowHTML">{{ item.value }}</span>
-                  </dd>
-                  <dd class="nhsuk-summary-list__actions">
-                    <a
-                      href="javascript:void(0);"
-                      routerLink="/{{ this.baseUrl }}/record/sections/{{ sectionInfo.id }}/edit/{{ item.editStepNumber }}"
-                      *ngIf="isInnovatorType && item.editStepNumber"
-                    >
-                      Change <span class="nhsuk-u-visually-hidden"> {{ item.label | lowercase }} </span></a
-                    >
-                  </dd>
-                </div>
-              </ng-container>
-            </ng-container>
-          </ng-container>
-
-          <ng-container *ngIf="!isSectionDetailsPage && documentsList.length > 0">
-            <ng-container *ngFor="let document of documentsList; index as i; first as firstItem; last as lastItem">
-              <div class="nhsuk-summary-list__row" [ngClass]="{ 'nhsuk-summary-list--no-border': !lastItem }">
-                <dt class="nhsuk-summary-list__key nhsuk-u-margin-padding-4">
-                  <span *ngIf="firstItem">Documents</span>
-                </dt>
-                <dd class="nhsuk-summary-list__value text-pre-wrap">
-                  <p>
-                    <span>Document {{ i + 1 }}: </span
-                    ><a href="{{ document.file.url }}"
-                      >{{ document.name }} ({{ document.file.extension | uppercase }}{{ document.file.size ? ", " + (document.file.size | bytesPrettyPrint) : "" }})</a
-                    >
-                  </p>
-                </dd>
-                <dd class="nhsuk-summary-list__actions">
-                  <a routerLink="/{{ baseUrl }}/documents/{{ document.id }}" attr.aria-label="View {{ document.name }} details">More details</a>
-                </dd>
-              </div>
-            </ng-container>
-          </ng-container>
-
-          <ng-container *ngIf="!isSectionDetailsPage && evidencesList.length > 0">
-            <ng-container *ngFor="let evidence of evidencesList; index as i; first as firstItem; last as lastItem">
-              <div class="nhsuk-summary-list__row" [ngClass]="{ 'nhsuk-summary-list--no-border': !lastItem }">
-                <dt class="nhsuk-summary-list__key nhsuk-u-margin-padding-4">
-                  <span *ngIf="firstItem">Evidence</span>
-                </dt>
-                <dd class="nhsuk-summary-list__value text-pre-wrap">
-                  <p>
-                    <span>Evidence {{ i + 1 }}: </span>{{ evidence.value }}
-                  </p>
-                </dd>
-                <dd class="nhsuk-summary-list__actions">
-                  <p><a href="{{ baseUrl }}/record/sections/{{ sectionInfo.id }}/evidences/{{ evidence.evidenceId }}">More details</a></p>
-                </dd>
-              </div>
-            </ng-container>
-          </ng-container>
-        </dl>
+      <ng-container *ngIf="(isAccessorType || isAssessmentType) && sectionInfo.status.id === 'DRAFT'; else showSummary">
+        <div class="nhsuk-inset-text nhsuk-u-margin-top-2 nhsuk-u-padding-top-0 nhsuk-u-padding-bottom-0">
+          <span class="nhsuk-u-visually-hidden">Information:</span>
+          <p>You cannot see this section because it is in draft. If you need to see this section, create a task or send a message to the innovator asking them to resubmit it.</p>
+        </div>
       </ng-container>
+
+      <ng-template #showSummary>
+        <ng-container *ngIf="summaryList.length > 0">
+          <dl class="nhsuk-summary-list nhsuk-u-margin-bottom-0">
+            <ng-container *ngFor="let item of summaryList" class="nhsuk-summary-list__row">
+              <ng-container [ngSwitch]="item.type">
+                <ng-container *ngSwitchCase="'button'">
+                  <div *ngIf="isInnovatorType" class="width-max-content">
+                    <dt class="nhsuk-u-margin-top-5">
+                      <a routerLink="edit/{{ item.editStepNumber }}" class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-0">{{ item.label }}</a>
+                    </dt>
+                  </div>
+                </ng-container>
+                <ng-container *ngSwitchDefault>
+                  <div class="nhsuk-summary-list__row">
+                    <dt class="nhsuk-summary-list__key nhsuk-u-margin-padding-4 nhsuk-u-padding-bottom-4">{{ item.label }}</dt>
+                    <dd class="nhsuk-summary-list__value text-pre-wrap">
+                      <span *ngIf="item.allowHTML" [innerHTML]="item.value"></span>
+                      <span *ngIf="!item.allowHTML">{{ item.value }}</span>
+                    </dd>
+                    <dd class="nhsuk-summary-list__actions">
+                      <a
+                        href="javascript:void(0);"
+                        routerLink="/{{ this.baseUrl }}/record/sections/{{ sectionInfo.id }}/edit/{{ item.editStepNumber }}"
+                        *ngIf="isInnovatorType && item.editStepNumber"
+                      >
+                        Change <span class="nhsuk-u-visually-hidden"> {{ item.label | lowercase }} </span></a
+                      >
+                    </dd>
+                  </div>
+                </ng-container>
+              </ng-container>
+            </ng-container>
+          </dl>
+        </ng-container>
+      </ng-template>
+
+      <dl class="nhsuk-summary-list nhsuk-u-margin-bottom-0">
+        <ng-container *ngIf="!isSectionDetailsPage && documentsList.length > 0">
+          <ng-container *ngFor="let document of documentsList; index as i; first as firstItem; last as lastItem">
+            <div class="nhsuk-summary-list__row" [ngClass]="{ 'nhsuk-summary-list--no-border': !lastItem }">
+              <dt class="nhsuk-summary-list__key nhsuk-u-margin-padding-4">
+                <span *ngIf="firstItem">Documents</span>
+              </dt>
+              <dd class="nhsuk-summary-list__value text-pre-wrap">
+                <p>
+                  <span>Document {{ i + 1 }}: </span
+                  ><a href="{{ document.file.url }}"
+                    >{{ document.name }} ({{ document.file.extension | uppercase }}{{ document.file.size ? ", " + (document.file.size | bytesPrettyPrint) : "" }})</a
+                  >
+                </p>
+              </dd>
+              <dd class="nhsuk-summary-list__actions">
+                <a routerLink="/{{ baseUrl }}/documents/{{ document.id }}" attr.aria-label="View {{ document.name }} details">More details</a>
+              </dd>
+            </div>
+          </ng-container>
+        </ng-container>
+
+        <ng-container *ngIf="!isSectionDetailsPage && evidencesList.length > 0">
+          <ng-container *ngFor="let evidence of evidencesList; index as i; first as firstItem; last as lastItem">
+            <div class="nhsuk-summary-list__row" [ngClass]="{ 'nhsuk-summary-list--no-border': !lastItem }">
+              <dt class="nhsuk-summary-list__key nhsuk-u-margin-padding-4">
+                <span *ngIf="firstItem">Evidence</span>
+              </dt>
+              <dd class="nhsuk-summary-list__value text-pre-wrap">
+                <p>
+                  <span>Evidence {{ i + 1 }}: </span>{{ evidence.value }}
+                </p>
+              </dd>
+              <dd class="nhsuk-summary-list__actions">
+                <p><a href="{{ baseUrl }}/record/sections/{{ sectionInfo.id }}/evidences/{{ evidence.evidenceId }}">More details</a></p>
+              </dd>
+            </div>
+          </ng-container>
+        </ng-container>
+      </dl>
     </ng-container>
   </div>
 </div>


### PR DESCRIPTION
- Fixed red 'X' inside section details page
- Passed draft inset message from section-info and section-info-all, into section-summary
- Separated lines for documents on section-summary to be displayed even when a section is in draft, for QA/A/NA.
- Refactored section-info and section-info-all, removing a function that was called to fetch data for the sections, on their respective templates.