### PR TITLE
moved lines from constructor to ngInit

### DIFF
--- a/src/modules/shared/pages/innovation/activity-log/innovation-activity-log.component.ts
+++ b/src/modules/shared/pages/innovation/activity-log/innovation-activity-log.component.ts
@@ -123,15 +123,15 @@ export class PageInnovationActivityLogComponent extends CoreComponent implements
     super();
     this.innovation = this.stores.context.getInnovation();
 
-    this.setPageTitle('Activity log');
-    this.setBackLink('Go back');
-
     this.activitiesList.setOrderBy('createdAt', 'descending');
     this.currentDateOrderBy = 'descending';
   }
 
   ngOnInit(): void {
     this.subscriptions.push(this.form.valueChanges.pipe(debounceTime(1000)).subscribe(() => this.onFormChange()));
+
+    this.setPageTitle('Activity log');
+    this.setBackLink('Go back');
 
     this.onFormChange();
   }


### PR DESCRIPTION
Fix for bug on Activity Log's page title where, if coming back from another page too fast, it would keep the previous title instead of 'Activity Log'.