### PR TITLE
Fix for IR page's wrong title when goback too quick

### DIFF
--- a/src/modules/shared/pages/innovation/record/innovation-record.component.ts
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.ts
@@ -52,7 +52,6 @@ export class PageInnovationRecordComponent extends CoreComponent implements OnIn
     private statisticsService: StatisticsService
   ) {
     super();
-    this.setPageTitle('Innovation record');
 
     this.innovationId = this.activatedRoute.snapshot.params.innovationId;
 
@@ -75,6 +74,8 @@ export class PageInnovationRecordComponent extends CoreComponent implements OnIn
   }
 
   ngOnInit(): void {
+    this.setPageTitle('Innovation record');
+
     forkJoin([
       this.stores.innovation.getSectionsSummary$(this.activatedRoute.snapshot.params.innovationId),
       ...(this.isInnovatorType


### PR DESCRIPTION
Fix for bug on IR's page title where, if coming back from another page too fast, it would keep the previous title instead of 'Innovation record'.