### PR TITLE
Fix for TASKS page's wrong title when go back too quick

### DIFF
--- a/src/modules/feature-modules/accessor/pages/innovations/innovations-review.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovations/innovations-review.component.ts
@@ -85,6 +85,16 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
       this.defaultStatus = 'UNASSIGNED';
       this.tabs = [
         {
+          key: InnovationSupportStatusEnum.ENGAGING,
+          title: 'All',
+          mainDescription: 'All innovations shared with your organisation.',
+          showAssignedToMeFilter: false,
+          showSuggestedOnlyFilter: false,
+          link: '/accessor/innovations',
+          queryParams: { status: InnovationSupportStatusEnum.ENGAGING },
+          notifications: null
+        },
+        {
           key: InnovationSupportStatusEnum.UNASSIGNED,
           title: 'Unassigned',
           mainDescription: 'Innovations awaiting status assignment from your organisation.',

--- a/src/modules/feature-modules/accessor/pages/innovations/innovations-review.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovations/innovations-review.component.ts
@@ -85,16 +85,6 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
       this.defaultStatus = 'UNASSIGNED';
       this.tabs = [
         {
-          key: InnovationSupportStatusEnum.ENGAGING,
-          title: 'All',
-          mainDescription: 'All innovations shared with your organisation.',
-          showAssignedToMeFilter: false,
-          showSuggestedOnlyFilter: false,
-          link: '/accessor/innovations',
-          queryParams: { status: InnovationSupportStatusEnum.ENGAGING },
-          notifications: null
-        },
-        {
           key: InnovationSupportStatusEnum.UNASSIGNED,
           title: 'Unassigned',
           mainDescription: 'Innovations awaiting status assignment from your organisation.',

--- a/src/modules/feature-modules/accessor/pages/tasks/tasks-list.component.ts
+++ b/src/modules/feature-modules/accessor/pages/tasks/tasks-list.component.ts
@@ -103,8 +103,8 @@ export class TasksListComponent extends CoreComponent implements OnInit {
         this.currentTab.index
       ].title.toLowerCase()} assigned by you`;
       if (this.isRunningOnBrowser() && column) this.tasksList.setFocusOnSortedColumnHeader(column);
-      this.setPageStatus('READY');
       this.setPageTitle('Tasks');
+      this.setPageStatus('READY');
     });
   }
 

--- a/src/modules/feature-modules/accessor/pages/tasks/tasks-list.component.ts
+++ b/src/modules/feature-modules/accessor/pages/tasks/tasks-list.component.ts
@@ -53,10 +53,10 @@ export class TasksListComponent extends CoreComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.setPageTitle('Tasks');
+
     this.subscriptions.push(
       this.activatedRoute.queryParams.subscribe(queryParams => {
-        this.setPageTitle('Tasks');
-
         if (!queryParams.openTasks) {
           this.router.navigate(['/accessor/tasks'], { queryParams: { openTasks: 'true' } });
           return;

--- a/src/modules/feature-modules/accessor/pages/tasks/tasks-list.component.ts
+++ b/src/modules/feature-modules/accessor/pages/tasks/tasks-list.component.ts
@@ -54,7 +54,6 @@ export class TasksListComponent extends CoreComponent implements OnInit {
 
   ngOnInit(): void {
     this.setPageTitle('Tasks');
-
     this.subscriptions.push(
       this.activatedRoute.queryParams.subscribe(queryParams => {
         if (!queryParams.openTasks) {
@@ -98,7 +97,6 @@ export class TasksListComponent extends CoreComponent implements OnInit {
 
   getTasksList(column?: string): void {
     this.setPageStatus('LOADING');
-
     this.innovationsService.getTasksList(this.tasksList.getAPIQueryParams()).subscribe(response => {
       this.tasksList.setData(response.data, response.count);
       this.currentTab.description = `${response.count} ${this.tabs[
@@ -106,6 +104,7 @@ export class TasksListComponent extends CoreComponent implements OnInit {
       ].title.toLowerCase()} assigned by you`;
       if (this.isRunningOnBrowser() && column) this.tasksList.setFocusOnSortedColumnHeader(column);
       this.setPageStatus('READY');
+      this.setPageTitle('Tasks');
     });
   }
 


### PR DESCRIPTION
Fix for bug on TASKS's page title where, if coming back from another page too fast, it would keep the previous title instead of 'Innovation record'.