### PR TITLE
Changes related to None option on innovation cards

### DIFF
--- a/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
+++ b/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
@@ -329,13 +329,13 @@ export class PageInnovationsAdvancedReviewComponent extends CoreComponent implem
                   ? 'None'
                   : keyHealthInequalitiesItems.find(entry => entry.value === item)?.label ?? item;
               })
-            : [];
+            : ['Question not answered'];
 
           const translatedAacInvolvement: string[] = result.involvedAACProgrammes
             ? result.involvedAACProgrammes.map(item => {
                 return item === 'No' ? 'None' : item;
               })
-            : [];
+            : ['Question not answered'];
 
           const engagingUnits = result.engagingUnits ? result.engagingUnits.map(unit => unit.acronym) : [];
 

--- a/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
+++ b/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
@@ -307,7 +307,7 @@ export class PageInnovationsAdvancedReviewComponent extends CoreComponent implem
                   ? categoriesItems.find(entry => entry.value === item)?.label ?? item
                   : result.otherCategoryDescription ?? item;
               })
-            : [];
+            : ['Question not answered'];
 
           const translatedCareSettings: string[] = result.careSettings
             ? result.careSettings.map(item => {
@@ -315,13 +315,13 @@ export class PageInnovationsAdvancedReviewComponent extends CoreComponent implem
                   ? careSettingsItems.find(entry => entry.value === item)?.label ?? item
                   : result.otherCareSetting ?? item;
               })
-            : [];
+            : ['Question not answered'];
 
           const translatedDiseasesAndConditions: string[] = result.diseasesAndConditions
             ? result.diseasesAndConditions.map(item => {
                 return diseasesConditionsImpactItems.find(entry => entry.value === item)?.label ?? item;
               })
-            : [];
+            : ['Question not answered'];
 
           const translatedKeyHealthInequalities: string[] = result.keyHealthInequalities
             ? result.keyHealthInequalities.map(item => {


### PR DESCRIPTION
- Added condition to return 'Question not answered' when payload is null: [AB#159097](https://dev.azure.com/NHSiDev/InnovatorService/_workitems/edit/159097)

![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/4017664/fad9a969-b729-44db-8612-21d46e2e2492)
