### PR TITLE
feat: create a standardized model for filters

### DIFF
--- a/src/modules/core/models/filters/filters.model.ts
+++ b/src/modules/core/models/filters/filters.model.ts
@@ -1,0 +1,98 @@
+import { FormGroup } from '@angular/forms';
+import { FilterHandler } from './handlers/base-filter.handler';
+import { FilterHandlerFactory } from './handlers/filter-handler.factory';
+
+export type Filter = BaseFilter & (CheckboxGroupFilter | CheckboxesFilter | DateRangeFilter);
+type BaseFilter = { key: string } & FilterOptions;
+
+type CheckboxesFilter = {
+  type: 'CHECKBOXES';
+  checkboxes: ({ key: string; title: string; defaultValue?: boolean } & FilterOptions)[];
+  selected?: { key: string; value: boolean }[];
+};
+
+type CheckboxGroupFilter = { type: 'CHECKBOX_GROUP'; selected?: { key: string; value: string }[] } & CollapsibleFilter;
+
+type DateRangeFilter = {
+  type: 'DATE_RANGE';
+  startDate: DateFilter;
+  endDate: DateFilter;
+  selected?: { key: string; value: string }[];
+} & CollapsibleFilter;
+
+type CollapsibleFilter = { title: string; description?: string; state: 'opened' | 'closed'; scrollable?: boolean };
+type DateFilter = { key: string; label: string; description?: string; defaultValue?: string };
+type FilterOptions = { options?: { updateOn?: 'blur' | 'change'; emitEvent?: boolean } };
+
+type Dataset = { value: string; label: string; description?: string }[];
+
+/**
+ * TODOS:
+ * Pre-load form with values (e.g., from localStorage)
+ * Handle checkbox group search by dataset (i.e., searchable to collapsible)
+ * Handle translations of selected values (e.g. INNOVATION_MANAGEMENT)
+ */
+export class FiltersModel {
+  form: FormGroup;
+
+  filters: Filter[];
+  handlers: Map<string, FilterHandler>;
+
+  #datasets: Map<string, Dataset>;
+
+  constructor(config?: Filter[]) {
+    this.form = new FormGroup({}, { updateOn: 'blur' });
+
+    this.filters = [];
+    this.handlers = new Map<string, FilterHandler>();
+
+    this.#datasets = new Map();
+
+    if (config) {
+      for (const filter of config) {
+        this.addFilter(filter);
+      }
+    }
+  }
+
+  addFilter(filter: Filter) {
+    this.filters.push(filter);
+
+    const handler = FilterHandlerFactory.create(filter, this.form);
+    handler.create(filter);
+    this.handlers.set(filter.key, handler);
+  }
+
+  addDatasets(datasets: Record<string, Dataset>) {
+    for (const [key, dataset] of Object.entries(datasets)) {
+      this.#datasets.set(key, dataset);
+    }
+  }
+
+  getCurrentStateFilters() {
+    const filters: Record<string, any> = {};
+    let selected = 0;
+
+    for (let filter of this.filters) {
+      const handler = this.handlers.get(filter.key)!;
+      filters[filter.key] = handler.value;
+      filter.selected = handler.getSelected();
+      selected += filter.selected.length ?? 0;
+
+      if (filter.type === 'CHECKBOX_GROUP' || filter.type === 'DATE_RANGE') {
+        filter.description = `${filter.selected?.length ?? 0} selected`;
+      }
+    }
+
+    return { filters, selected };
+  }
+
+  getDataset(filter: Filter) {
+    return this.#datasets.get(filter.key) ?? [];
+  }
+
+  removeSelection(filterKey: string, key: string) {
+    const handler = this.handlers.get(filterKey)!;
+    handler.delete(key);
+  }
+}

--- a/src/modules/core/models/filters/filters.model.ts
+++ b/src/modules/core/models/filters/filters.model.ts
@@ -8,7 +8,7 @@ type BaseFilter = { key: string } & FilterOptions;
 
 type CheckboxesFilter = {
   type: 'CHECKBOXES';
-  checkboxes: ({ key: string; title: string; defaultValue?: boolean } & FilterOptions)[];
+  checkboxes: ({ title: string; defaultValue?: boolean } & BaseFilter)[];
   selected?: { key: string; value: boolean }[];
 };
 
@@ -58,6 +58,7 @@ export class FiltersModel {
   addFilter(filter: Filter) {
     this.filters.push(filter);
 
+    // To truly decouple this factory, it should be injected from the constructor.
     const handler = FilterHandlerFactory.create(filter, this.form);
     handler.create(filter);
     this.handlers.set(filter.key, handler);

--- a/src/modules/core/models/filters/filters.model.ts
+++ b/src/modules/core/models/filters/filters.model.ts
@@ -1,5 +1,6 @@
 import { FormGroup } from '@angular/forms';
 import { FilterHandler } from './handlers/base-filter.handler';
+import { CheckboxGroupHandler } from './handlers/checkbox-group.handler';
 import { FilterHandlerFactory } from './handlers/filter-handler.factory';
 
 export type Filter = BaseFilter & (CheckboxGroupFilter | CheckboxesFilter | DateRangeFilter);
@@ -30,7 +31,6 @@ type Dataset = { value: string; label: string; description?: string }[];
  * TODOS:
  * Pre-load form with values (e.g., from localStorage)
  * Handle checkbox group search by dataset (i.e., searchable to collapsible)
- * Handle translations of selected values (e.g. INNOVATION_MANAGEMENT)
  */
 export class FiltersModel {
   form: FormGroup;
@@ -66,6 +66,11 @@ export class FiltersModel {
   addDatasets(datasets: Record<string, Dataset>) {
     for (const [key, dataset] of Object.entries(datasets)) {
       this.#datasets.set(key, dataset);
+
+      const handler = this.handlers.get(key);
+      if (handler instanceof CheckboxGroupHandler) {
+        handler.translation = dataset.map(c => ({ key: c.value, value: c.label }));
+      }
     }
   }
 

--- a/src/modules/core/models/filters/handlers/base-filter.handler.ts
+++ b/src/modules/core/models/filters/handlers/base-filter.handler.ts
@@ -1,0 +1,26 @@
+import { FormGroup } from '@angular/forms';
+
+import { Filter } from '../filters.model';
+
+export abstract class FilterHandler {
+  protected readonly id: string;
+  protected readonly form: FormGroup;
+
+  constructor(id: string, form: FormGroup) {
+    this.id = id;
+    this.form = form;
+  }
+
+  abstract get value():
+    | string[]
+    | { key: string; startDate: string | null; endDate: string | null }
+    | Record<string, boolean>
+    | null;
+
+  abstract create(filter: Filter): void;
+
+  abstract getSelected(): { key: string; value: string }[] | { key: string; value: boolean }[];
+  abstract setSelected(value: { key?: string; value: string | string[] | boolean | null }): void;
+
+  abstract delete(key: string): void;
+}

--- a/src/modules/core/models/filters/handlers/checkbox-group.hander.ts
+++ b/src/modules/core/models/filters/handlers/checkbox-group.hander.ts
@@ -1,0 +1,39 @@
+import { FormArray, FormControl, FormGroup } from '@angular/forms';
+
+import { Filter } from '../filters.model';
+import { FilterHandler } from './base-filter.handler';
+
+export class CheckboxGroupHandler extends FilterHandler {
+  get control(): FormArray {
+    return this.form.get(this.id) as FormArray;
+  }
+
+  get value(): string[] {
+    return this.control.value;
+  }
+
+  constructor(id: string, form: FormGroup) {
+    super(id, form);
+  }
+
+  create(filter: Filter): void {
+    this.form.addControl(this.id, new FormArray([], { updateOn: filter.options?.updateOn }), { emitEvent: false });
+  }
+
+  getSelected(): { key: string; value: string }[] {
+    return this.value.map(v => ({ key: v, value: v })); // TODO: Have to handle translation???
+  }
+
+  setSelected({ value }: { value: string[] }): void {
+    value.forEach(v => this.control.push(new FormControl(v), { emitEvent: true }));
+  }
+
+  delete(key: string): void {
+    const control = this.control;
+    const index = control.controls.findIndex(i => i.value === key);
+
+    if (index > -1) {
+      control.removeAt(index);
+    }
+  }
+}

--- a/src/modules/core/models/filters/handlers/checkbox-group.handler.ts
+++ b/src/modules/core/models/filters/handlers/checkbox-group.handler.ts
@@ -4,12 +4,18 @@ import { Filter } from '../filters.model';
 import { FilterHandler } from './base-filter.handler';
 
 export class CheckboxGroupHandler extends FilterHandler {
+  #translation?: { key: string; value: string }[];
+
   get control(): FormArray {
     return this.form.get(this.id) as FormArray;
   }
 
   get value(): string[] {
     return this.control.value;
+  }
+
+  set translation(translation: { key: string; value: string }[]) {
+    this.#translation = translation;
   }
 
   constructor(id: string, form: FormGroup) {
@@ -21,7 +27,12 @@ export class CheckboxGroupHandler extends FilterHandler {
   }
 
   getSelected(): { key: string; value: string }[] {
-    return this.value.map(v => ({ key: v, value: v })); // TODO: Have to handle translation???
+    const selected = this.value;
+    if (!this.#translation) {
+      return selected.map(v => ({ key: v, value: v }));
+    }
+
+    return this.#translation.filter(cur => selected.includes(cur.key));
   }
 
   setSelected({ value }: { value: string[] }): void {

--- a/src/modules/core/models/filters/handlers/checkboxes.handler.ts
+++ b/src/modules/core/models/filters/handlers/checkboxes.handler.ts
@@ -1,0 +1,56 @@
+import { FormControl, FormGroup } from '@angular/forms';
+
+import { Filter } from '../filters.model';
+import { FilterHandler } from './base-filter.handler';
+
+export class CheckboxesHandler extends FilterHandler {
+  #keys: Set<string>;
+
+  get value(): Record<string, boolean> {
+    const values: Record<string, boolean> = {};
+    for (const key of this.#keys) {
+      values[key] = this.#getControl(key).value;
+    }
+    return values;
+  }
+
+  constructor(id: string, form: FormGroup) {
+    super(id, form);
+    this.#keys = new Set();
+  }
+
+  create(filter: Filter): void {
+    if (filter.type !== 'CHECKBOXES') {
+      throw new Error('A filter of type Checkboxes has to be passed to this handler.');
+    }
+
+    for (const checkbox of filter.checkboxes) {
+      this.#keys.add(checkbox.key);
+
+      this.form.addControl(
+        checkbox.key,
+        new FormControl(checkbox.defaultValue ?? false, { updateOn: checkbox.options?.updateOn }),
+        { emitEvent: false }
+      );
+    }
+  }
+
+  getSelected(): { key: string; value: boolean }[] {
+    return Object.entries(this.value).flatMap(([key, value]) => (value ? [{ key, value }] : []));
+  }
+
+  setSelected({ key, value }: { key: string; value: boolean }): void {
+    if (!key || !this.#keys.has(key)) {
+      throw new Error('A valid key has to be defined');
+    }
+    this.#getControl(key).patchValue(value, { emitEvent: true });
+  }
+
+  delete(key: string): void {
+    this.setSelected({ key, value: false });
+  }
+
+  #getControl(key: string): FormControl {
+    return this.form.get(key) as FormControl;
+  }
+}

--- a/src/modules/core/models/filters/handlers/date-range.handler.ts
+++ b/src/modules/core/models/filters/handlers/date-range.handler.ts
@@ -1,0 +1,73 @@
+import { FormControl, FormGroup } from '@angular/forms';
+import { DatesHelper } from '@app/base/helpers';
+import { CustomValidators } from '@modules/shared/forms';
+
+import { Filter } from '../filters.model';
+import { FilterHandler } from './base-filter.handler';
+
+export class DateRangeHandler extends FilterHandler {
+  #keys: Set<string>;
+
+  get value(): { key: string; startDate: string | null; endDate: string | null } | null {
+    const [startKey, endKey] = this.#keys;
+    const startDate = this.#getDate(startKey);
+    const endDate = this.#getDate(endKey);
+
+    if (startDate || endDate) {
+      return { key: this.id, startDate, endDate };
+    }
+
+    return null;
+  }
+
+  constructor(id: string, form: FormGroup) {
+    super(id, form);
+    this.#keys = new Set([this.#generateKey('startDate'), this.#generateKey('endDate')]);
+  }
+
+  create(filter: Filter): void {
+    for (const key of this.#keys) {
+      this.form.addControl(
+        key,
+        new FormControl(null, {
+          validators: CustomValidators.parsedDateStringValidator(),
+          updateOn: filter.options?.updateOn
+        }),
+        { emitEvent: false }
+      );
+    }
+  }
+
+  getSelected(): { key: string; value: string }[] {
+    const value = this.value;
+    if (!value) {
+      return [];
+    }
+
+    return [
+      ...(value.startDate !== null ? [{ key: 'startDate', value: value.startDate }] : []),
+      ...(value.endDate !== null ? [{ key: 'endDate', value: value.endDate }] : [])
+    ];
+  }
+
+  setSelected({ key, value }: { key: string; value: string | null }): void {
+    const control = this.#getControl(this.#generateKey(key));
+    control.patchValue(DatesHelper.parseIntoValidFormat(value), { emitEvent: true });
+  }
+
+  delete(key: string): void {
+    this.setSelected({ key, value: null });
+  }
+
+  #getDate(key: string): string | null {
+    return DatesHelper.parseIntoValidFormat(this.#getControl(key).value);
+  }
+
+  #getControl(key: string): FormControl {
+    return this.form.get(key) as FormControl;
+  }
+
+  #generateKey(key: string) {
+    return `${this.id}::${key}`;
+  }
+}

--- a/src/modules/core/models/filters/handlers/filter-handler.factory.ts
+++ b/src/modules/core/models/filters/handlers/filter-handler.factory.ts
@@ -1,0 +1,15 @@
+import { FormGroup } from '@angular/forms';
+import { Filter } from '../filters.model';
+import { FilterHandler } from './base-filter.handler';
+import { CheckboxGroupHandler } from './checkbox-group.hander';
+import { CheckboxesHandler } from './checkboxes.handler';
+import { DateRangeHandler } from './date-range.handler';
+
+export class FilterHandlerFactory {
+  static create(filter: Filter, form: FormGroup): FilterHandler {
+    if (filter.type === 'CHECKBOX_GROUP') return new CheckboxGroupHandler(filter.key, form);
+    if (filter.type === 'CHECKBOXES') return new CheckboxesHandler(filter.key, form);
+    if (filter.type === 'DATE_RANGE') return new DateRangeHandler(filter.key, form);
+    throw new Error('Filter Handler is not defined');
+  }
+}

--- a/src/modules/core/models/filters/handlers/filter-handler.factory.ts
+++ b/src/modules/core/models/filters/handlers/filter-handler.factory.ts
@@ -1,7 +1,7 @@
 import { FormGroup } from '@angular/forms';
 import { Filter } from '../filters.model';
 import { FilterHandler } from './base-filter.handler';
-import { CheckboxGroupHandler } from './checkbox-group.hander';
+import { CheckboxGroupHandler } from './checkbox-group.handler';
 import { CheckboxesHandler } from './checkboxes.handler';
 import { DateRangeHandler } from './date-range.handler';
 


### PR DESCRIPTION
Filter model enables:
- Load/Add new filters through a config or directly
- Add datasets for filters that needs it (only checkbox group for now)
- Get dataset for a filter
- Remove selection of filters
- Get a standardised state output from the displayed filters

Filter handlers:
- Standard and extensible way of handling common operations of filters
- Currently implementation enables (taking into consideration the different behaviours of checkbox group, date ranges, and checkboxes):
	- Creation of control
	- Getting current control value already formatted to be sent in the API payload
	- Get selection values
	- Set selection values
	- Delete a current selection value


TODOS:
- Pre-load form with values (e.g., from localStorage)
- Handle checkbox group search by dataset (i.e., searchable to collapsible)
- ~~Handle translations of selected values (e.g. INNOVATION_MANAGEMENT)~~
- Improve types?