### PR TITLE
Fix: extra line on filter and wrong empty state

### DIFF
--- a/src/modules/shared/pages/innovations/innovations-advanced-review.component.html
+++ b/src/modules/shared/pages/innovations/innovations-advanced-review.component.html
@@ -79,12 +79,8 @@
       <dl class="nhsuk-u-margin-top-1 nhsuk-u-margin-bottom-1 nhsuk-u-padding-2 bg-color-grey">
         <dt *ngIf="!anyFilterSelected" class="nhsuk-u-font-size-16">No filter has been selected</dt>
 
-        <ng-container *ngFor="let filter of this.filtersModel.filters; last as isLast">
-          <div
-            *ngIf="filter.selected?.length && filter.type !== 'CHECKBOXES'"
-            class="d-flex align-items-center"
-            [ngClass]="isAdminType && isLast ? 'border-bottom-0' : 'border-bottom-neutral'"
-          >
+        <ng-container *ngFor="let filter of this.filtersModel.selected$ | async; last as isLast">
+          <div class="d-flex align-items-center" [ngClass]="isLast ? 'border-bottom-0' : 'border-bottom-neutral'">
             <ng-container *ngIf="filter.type === 'CHECKBOX_GROUP'">
               <dt class="width-20 nhsuk-u-font-size-16">{{ filter.title }}</dt>
               <dd class="width-75">
@@ -113,16 +109,14 @@
                 </ng-container>
               </dd>
             </ng-container>
-          </div>
-        </ng-container>
 
-        <ng-container *ngFor="let filter of this.filtersModel.filters">
-          <div *ngIf="filter.type === 'CHECKBOXES'">
-            <ng-container *ngFor="let checkbox of filter.selected">
-              <!-- TODO: Think of a better way to make this dynamic -->
-              <dt *ngIf="checkbox.key === 'assignedToMe'" class="nhsuk-u-font-size-16 nhsuk-u-margin-top-2">Viewing innovations assigned to me</dt>
-              <dt *ngIf="checkbox.key === 'suggestedOnly'" class="nhsuk-u-font-size-16 nhsuk-u-margin-top-2">Viewing suggested innovations</dt>
-            </ng-container>
+            <div *ngIf="filter.type === 'CHECKBOXES'">
+              <ng-container *ngFor="let checkbox of filter.selected">
+                <!-- TODO: Think of a better way to make this dynamic -->
+                <dt *ngIf="checkbox.key === 'assignedToMe'" class="nhsuk-u-font-size-16 nhsuk-u-margin-top-2">Viewing innovations assigned to me</dt>
+                <dt *ngIf="checkbox.key === 'suggestedOnly'" class="nhsuk-u-font-size-16 nhsuk-u-margin-top-2">Viewing suggested innovations</dt>
+              </ng-container>
+            </div>
           </div>
         </ng-container>
       </dl>

--- a/src/modules/shared/pages/innovations/innovations-advanced-review.component.html
+++ b/src/modules/shared/pages/innovations/innovations-advanced-review.component.html
@@ -124,13 +124,14 @@
       <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-u-margin-top-2" />
 
       <ng-container *ngIf="innovationCardsData.length === 0">
-        <p class="nhsuk-u-padding-top-4">There are no matching results.</p>
+        <p class="nhsuk-u-padding-top-4 nhsuk-u-font-weight-bold">There are no matching results.</p>
         <p class="nhsuk-u-margin-bottom-2">Improve your search results by:</p>
         <ul>
           <li>removing filters</li>
           <li>double-checking your spelling</li>
           <li>using fewer words</li>
           <li>searching for something less specific</li>
+          <li>checking or increasing the date range</li>
         </ul>
       </ng-container>
 

--- a/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
+++ b/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
@@ -154,7 +154,8 @@ export class PageInnovationsAdvancedReviewComponent extends CoreComponent implem
     this.paginationParams.order = { [this.orderBy]: ['ascending'].includes(this.orderDir) ? 'ASC' : 'DESC' };
     this.paginationParams.skip = (this.pageNumber - 1) * this.pageSize;
 
-    const { filters } = this.filtersModel.getCurrentStateFilters();
+    const { filters, selected } = this.filtersModel.getCurrentStateFilters();
+    this.anyFilterSelected = selected > 0;
     const apiQueryFilters = Object.fromEntries(Object.entries(filters).filter(([_k, v]) => !UtilsHelper.isEmpty(v)));
 
     let queryFields: Parameters<InnovationsService['getInnovationsList2']>[0] = [
@@ -234,8 +235,6 @@ export class PageInnovationsAdvancedReviewComponent extends CoreComponent implem
   onFormChange(): void {
     this.setPageStatus('LOADING');
 
-    const state = this.filtersModel.getCurrentStateFilters();
-    this.anyFilterSelected = state.selected > 0;
     this.pageNumber = 1;
 
     // persist in session storage


### PR DESCRIPTION
Fixes related with advanced list:
- Extra line below the filters when no checkboxes are selected
    - Improved the getSelected to remove unnecessary refresh's and recalculations
- Empty state message was not right