### PR TITLE
Fix/improve handling of date range invalids and clear filters

### DIFF
--- a/src/modules/core/models/filters/filters.model.ts
+++ b/src/modules/core/models/filters/filters.model.ts
@@ -193,11 +193,21 @@ export class FiltersModel {
   }
 
   clearAll(): void {
+    // If search is available reset the value
     if (this.search) {
       this.form.get(this.search.key)?.patchValue('');
     }
+
+    // Reset all filters values
     for (const handler of this.handlers.values()) {
       handler.reset();
+    }
+
+    // Reset checkbox group items to their default
+    for (const filter of this.filters) {
+      if (filter.type === 'CHECKBOX_GROUP' && filter.searchable) {
+        this.updateDataset(filter, '');
+      }
     }
   }
 

--- a/src/modules/shared/pages/innovations/innovations-advanced-review.component.html
+++ b/src/modules/shared/pages/innovations/innovations-advanced-review.component.html
@@ -36,6 +36,7 @@
           <ng-container *ngIf="filter.type === 'CHECKBOX_GROUP'">
             <theme-collapsible-filter [title]="filter.title" [description]="filter.description" [preOpen]="filter.state === 'opened'" [scrollable]="filter.scrollable">
               <input
+                #autocompleteSearchInput
                 *ngIf="filter.searchable"
                 fixedContentContainer
                 id="{{ filter.key }}CheckboxInputFilter"

--- a/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
+++ b/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
@@ -235,7 +235,6 @@ export class PageInnovationsAdvancedReviewComponent extends CoreComponent implem
   onFormChange(): void {
     if (!this.form.valid) {
       this.form.markAllAsTouched();
-      return;
     }
 
     this.pageNumber = 1;

--- a/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
+++ b/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit, QueryList, ViewChildren } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { debounceTime } from 'rxjs/operators';
 
@@ -34,6 +34,8 @@ type AdvancedReviewSortByKeysType = {
   templateUrl: './innovations-advanced-review.component.html'
 })
 export class PageInnovationsAdvancedReviewComponent extends CoreComponent implements OnInit {
+  @ViewChildren('autocompleteSearchInput') autocompleteInputs?: QueryList<ElementRef<HTMLInputElement>>;
+
   baseUrl: string;
 
   isAdminType: boolean;
@@ -277,6 +279,7 @@ export class PageInnovationsAdvancedReviewComponent extends CoreComponent implem
   }
 
   clearFilters(): void {
+    this.autocompleteInputs?.forEach(i => (i.nativeElement.value = ''));
     this.filtersModel.clearAll();
   }
 


### PR DESCRIPTION
- Don't block search when date range is invalid (same behaviour as gov.uk).
- Clear filters also clears the autocomplete inputs.