### PR TITLE
fix: health inequalities and involved AAC don't have exclusives on filters

### DIFF
--- a/src/modules/shared/pages/innovations/innovations-advanced-review.config.ts
+++ b/src/modules/shared/pages/innovations/innovations-advanced-review.config.ts
@@ -96,8 +96,8 @@ const InnovationListDatasets: Record<string, Dataset> = {
   diseasesAndConditions: diseasesConditionsImpactItems,
   categories: [...categoriesItems, { value: 'OTHER', label: 'Other' }],
   careSettings: [...careSettingsItems, { value: 'OTHER', label: 'Other' }],
-  keyHealthInequalities: keyHealthInequalitiesItems.filter(i => i.label !== 'SEPARATOR'),
-  involvedAACProgrammes: involvedAACProgrammesItems.filter(i => i.label !== 'SEPARATOR')
+  keyHealthInequalities: keyHealthInequalitiesItems.filter(i => i.label !== 'SEPARATOR').map(i => ({ value: i.value, label: i.label }) ),
+  involvedAACProgrammes: involvedAACProgrammesItems.filter(i => i.label !== 'SEPARATOR').map(i => ({ value: i.value, label: i.label }) )
 };
 
 export function getConfig(role?: UserRoleEnum): { filters: FiltersConfig; datasets: Record<string, Dataset> } {


### PR DESCRIPTION
- The raw items have exclusive items, which means that when you selected 'NO' or 'NONE,' it was disselecting the others.