### PR TITLE
Bugfix/144360 It's possible to open "Documents" by URL when a user should not have access

### DIFF
--- a/src/modules/feature-modules/innovator/guards/new-innovation-forbidden-page.guard.ts
+++ b/src/modules/feature-modules/innovator/guards/new-innovation-forbidden-page.guard.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { InnovationsService } from '@modules/shared/services/innovations.service';
+import { Observable, map, catchError, of } from 'rxjs';
+
+@Injectable()
+export class NewInnovationForbiddenPageGuard {
+  constructor(
+    private router: Router,
+    private innovationsService: InnovationsService
+  ) {}
+
+  canActivate(route: ActivatedRouteSnapshot): Observable<boolean> {
+    const innovationId = route.params.innovationId;
+
+    return this.innovationsService.getInnovationInfo(innovationId).pipe(
+      map((innovation: { status: string }) => {
+        if (innovation.status !== 'CREATED') {
+          return true;
+        } else {
+          this.router.navigateByUrl('error/forbidden-innovation');
+          return false;
+        }
+      }),
+      catchError(() => {
+        this.router.navigateByUrl('error/generic');
+        return of(false);
+      })
+    );
+  }
+}

--- a/src/modules/feature-modules/innovator/innovator-routing.module.ts
+++ b/src/modules/feature-modules/innovator/innovator-routing.module.ts
@@ -93,6 +93,7 @@ import { InnovationThreadDataResolver } from '@modules/shared/resolvers/innovati
 import { PageInnovationManageAccessLeaveInnovationComponent } from './pages/innovation/manage-access/manage-access-leave-innovation.component';
 import { PageInnovationManageAccessOverviewComponent } from './pages/innovation/manage-access/manage-access-overview.component';
 import { PageInnovationAllSectionsInfoComponent } from '@modules/shared/pages/innovation/sections/section-info-all.component';
+import { NewInnovationForbiddenPageGuard } from './guards/new-innovation-forbidden-page.guard';
 
 const header: RoutesDataType['header'] = {
   menuBarItems: {
@@ -350,6 +351,7 @@ const routes: Routes = [
 
               {
                 path: 'documents',
+                canActivate: mapToCanActivate([NewInnovationForbiddenPageGuard]),
                 data: { breadcrumb: 'Documents' },
                 children: [
                   {
@@ -506,6 +508,7 @@ const routes: Routes = [
 
               {
                 path: 'support-summary',
+                canActivate: mapToCanActivate([NewInnovationForbiddenPageGuard]),
                 data: { breadcrumb: 'Support summary' },
                 children: [
                   {

--- a/src/modules/feature-modules/innovator/innovator.module.ts
+++ b/src/modules/feature-modules/innovator/innovator.module.ts
@@ -49,6 +49,7 @@ import { ShareInnovationRecordGuard } from './guards/share-innovation-record.gua
 
 // Services.
 import { InnovatorService } from './services/innovator.service';
+import { NewInnovationForbiddenPageGuard } from './guards/new-innovation-forbidden-page.guard';
 
 @NgModule({
   imports: [ThemeModule, SharedModule, InnovatorRoutingModule],
@@ -95,6 +96,7 @@ import { InnovatorService } from './services/innovator.service';
     FirstTimeSigninGuard,
     ManageGuard,
     ShareInnovationRecordGuard,
+    NewInnovationForbiddenPageGuard,
 
     // Services.
     InnovatorService


### PR DESCRIPTION
- Created Guard for innovator, to redirect to innovation error page when Innovator tries to access forbidden pages for an innovation which has 'CREATED' status (namely 'documents' and 'support-summary')

 