### PR TITLE
Removed "Accelerate Wales" and "Telehealth"  bullet points on referral criteria page, associated to Life Science Hub Wales  organisation

### DIFF
--- a/src/modules/feature-modules/accessor/pages/organisation-referral-criteria/organisation-referral-criteria.component.ts
+++ b/src/modules/feature-modules/accessor/pages/organisation-referral-criteria/organisation-referral-criteria.component.ts
@@ -210,7 +210,7 @@ export class InnovationSupportOrganisationReferralCriteriaComponent extends Core
         },
         {
           type: 'BULLET_LIST',
-          values: [{ description: 'Accelerate Wales' }, { description: 'Digital Health Ecosystem Wales (DHEW)' }]
+          values: [{ description: 'Digital Health Ecosystem Wales (DHEW)' }]
         },
         {
           type: 'PARAGRAPH',
@@ -229,7 +229,7 @@ export class InnovationSupportOrganisationReferralCriteriaComponent extends Core
             { description: 'Access to Science Parks' },
             {
               description: 'Subject Expertise and Thematic Focus Groups',
-              subBullets: ['Digital & AI', 'Telehealth', 'Precision medicine (advanced therapies, early diagnostics)']
+              subBullets: ['Digital & AI', 'Precision medicine (advanced therapies, early diagnostics)']
             },
             { description: 'User Centred Design / Product Design' },
             { description: 'Research and Development' },


### PR DESCRIPTION
Closes [AB#159900](https://dev.azure.com/NHSiDev/InnovatorService/_workitems/edit/159900)

![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/124596230/8cf5c73c-e54c-4ffb-8d39-0729a8f75450)
