### PR TITLE
Bugfix/160596 cards show none when select no on diseases question

### DIFF
--- a/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
+++ b/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
@@ -197,9 +197,6 @@ export class PageInnovationsAdvancedReviewComponent extends CoreComponent implem
 
         response.data.forEach(result => {
           const translatedAacInvolvement = result.involvedAACProgrammes?.map(item => (item === 'No' ? 'None' : item));
-          const translatedDiseases = result.diseasesAndConditions?.length
-            ? result.diseasesAndConditions?.map(item => (item === 'NONE' ? 'None' : item))
-            : ['Question not answered'];
           const engagingUnits = result.engagingUnits ? result.engagingUnits.map(unit => unit.acronym) : [];
 
           const innovationData: InnovationCardData = {

--- a/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
+++ b/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
@@ -210,7 +210,11 @@ export class PageInnovationsAdvancedReviewComponent extends CoreComponent implem
             postCode: result.postcode,
             categories: this.translateLists(result.categories, categoriesItems, result.otherCategoryDescription),
             careSettings: this.translateLists(result.careSettings, careSettingsItems, result.otherCareSetting),
-            diseasesAndConditions: translatedDiseases,
+            diseasesAndConditions: this.translateLists(
+              result.diseasesAndConditions,
+              diseasesConditionsImpactItems,
+              'None'
+            ),
             keyHealthInequalities: this.translateLists(
               result.keyHealthInequalities,
               keyHealthInequalitiesItems,

--- a/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
+++ b/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
@@ -197,6 +197,9 @@ export class PageInnovationsAdvancedReviewComponent extends CoreComponent implem
 
         response.data.forEach(result => {
           const translatedAacInvolvement = result.involvedAACProgrammes?.map(item => (item === 'No' ? 'None' : item));
+          const translatedDiseases = result.diseasesAndConditions?.length
+            ? result.diseasesAndConditions?.map(item => (item === 'NONE' ? 'None' : item))
+            : ['Question not answered'];
           const engagingUnits = result.engagingUnits ? result.engagingUnits.map(unit => unit.acronym) : [];
 
           const innovationData: InnovationCardData = {
@@ -207,7 +210,7 @@ export class PageInnovationsAdvancedReviewComponent extends CoreComponent implem
             postCode: result.postcode,
             categories: this.translateLists(result.categories, categoriesItems, result.otherCategoryDescription),
             careSettings: this.translateLists(result.careSettings, careSettingsItems, result.otherCareSetting),
-            diseasesAndConditions: this.translateLists(result.diseasesAndConditions, diseasesConditionsImpactItems),
+            diseasesAndConditions: translatedDiseases,
             keyHealthInequalities: this.translateLists(
               result.keyHealthInequalities,
               keyHealthInequalitiesItems,

--- a/src/modules/stores/innovation/innovation-record/202304/section-2-1.config.ts
+++ b/src/modules/stores/innovation/innovation-record/202304/section-2-1.config.ts
@@ -161,7 +161,8 @@ function runtimeRules(steps: WizardStepType[], data: StepPayloadType, currentSte
       })
     );
   } else {
-    delete data.diseasesConditionsImpact;
+    data.diseasesConditionsImpact = ['None'];
+    // delete data.diseasesConditionsImpact;
   }
 
   steps.push(

--- a/src/modules/stores/innovation/innovation-record/202304/section-2-1.config.ts
+++ b/src/modules/stores/innovation/innovation-record/202304/section-2-1.config.ts
@@ -161,8 +161,7 @@ function runtimeRules(steps: WizardStepType[], data: StepPayloadType, currentSte
       })
     );
   } else {
-    data.diseasesConditionsImpact = ['None'];
-    // delete data.diseasesConditionsImpact;
+    data.diseasesConditionsImpact = ['NONE'];
   }
 
   steps.push(


### PR DESCRIPTION
- Changed IR wizard to send ['NONE'] when 'No' is selected on question 2.1.4 ("Does your innovation impact a disease or condition?")

Closes task [AB#160596](https://nhsidev.visualstudio.com/InnovatorService/_sprints/taskboard/Development%20Team/InnovatorService/NHS_InnovationService_Sprint_36?workitem=160596)

