### PR TITLE
Fix / fix for IR section 2.1 when adding diseases

### DIFF
--- a/src/modules/stores/innovation/innovation-record/202304/section-2-1.config.ts
+++ b/src/modules/stores/innovation/innovation-record/202304/section-2-1.config.ts
@@ -146,6 +146,10 @@ function runtimeRules(steps: WizardStepType[], data: StepPayloadType, currentSte
   steps.splice(4);
 
   if (data.impactDiseaseCondition === 'YES') {
+    data.diseasesConditionsImpact = data.diseasesConditionsImpact?.filter(item =>
+      diseasesConditionsImpactItems.flatMap(item => item.value).includes(item)
+    );
+
     steps.push(
       new FormEngineModel({
         parameters: [


### PR DESCRIPTION
Fix for bug on IR question "Does your innovation impact a disease or condition?", showing 'You have chosen 1 item' when answering question 'YES', after having previously submitted 'NO', even though no items are currently selected.