### PR TITLE
Task/160718 archived innovation impacts on the header and overview page

### DIFF
--- a/src/modules/feature-modules/accessor/base/context-innovation-outlet.component.html
+++ b/src/modules/feature-modules/accessor/base/context-innovation-outlet.component.html
@@ -4,5 +4,7 @@
     <a *ngIf="data.link" [routerLink]="data.link.url">{{ data.link.label }}</a>
   </div>
 
+  <theme-header-archived-banner />
+
   <hr class="nhsuk-section-break nhsuk-section-break--visible" />
 </div>

--- a/src/modules/feature-modules/accessor/base/context-innovation-outlet.component.ts
+++ b/src/modules/feature-modules/accessor/base/context-innovation-outlet.component.ts
@@ -27,13 +27,15 @@ export class ContextInnovationOutletComponent implements OnDestroy {
         .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
         .subscribe(e => this.onRouteChange(e))
     );
+
+    this.subscriptions.unsubscribe();
   }
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
   }
 
-  private onRouteChange(event: NavigationEnd): void {
+  private onRouteChange(event?: NavigationEnd): void {
     const innovation = this.contextStore.getInnovation();
     this.data.innovation = {
       id: innovation.id,
@@ -43,7 +45,10 @@ export class ContextInnovationOutletComponent implements OnDestroy {
     };
 
     // Do not show link, ON assessments route.
-    if (event.url.endsWith(`/assessments/${innovation.assessment?.id}`) || innovation.status === 'ARCHIVED') {
+    if (
+      (event && event.url.endsWith(`/assessments/${innovation.assessment?.id}`)) ||
+      innovation.status === 'ARCHIVED'
+    ) {
       this.data.link = null;
     } else {
       this.data.link = {

--- a/src/modules/feature-modules/accessor/base/context-innovation-outlet.component.ts
+++ b/src/modules/feature-modules/accessor/base/context-innovation-outlet.component.ts
@@ -43,7 +43,7 @@ export class ContextInnovationOutletComponent implements OnDestroy {
     };
 
     // Do not show link, ON assessments route.
-    if (event.url.endsWith(`/assessments/${innovation.assessment?.id}`)) {
+    if (event.url.endsWith(`/assessments/${innovation.assessment?.id}`) || innovation.status === 'ARCHIVED') {
       this.data.link = null;
     } else {
       this.data.link = {

--- a/src/modules/feature-modules/accessor/base/context-innovation-outlet.component.ts
+++ b/src/modules/feature-modules/accessor/base/context-innovation-outlet.component.ts
@@ -28,7 +28,7 @@ export class ContextInnovationOutletComponent implements OnDestroy {
         .subscribe(e => this.onRouteChange(e))
     );
 
-    this.subscriptions.unsubscribe();
+    this.onRouteChange();
   }
 
   ngOnDestroy(): void {

--- a/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.html
+++ b/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.html
@@ -17,7 +17,7 @@
             label="{{ 'shared.catalog.innovation.support_status.' + innovationSupport.status + '.name' | translate }}"
           ></theme-tag>
         </dd>
-        <dd *ngIf="innovation.status !== 'ARCHIVED'" class="nhsuk-summary-list__actions width-25">
+        <dd *ngIf="!isArchived" class="nhsuk-summary-list__actions width-25">
           <a
             *ngIf="isQualifyingAccessorRole && innovationSupport.status !== 'UNASSIGNED'"
             routerLink="/accessor/innovations/{{ innovationId }}/support/{{ innovation.support?.id || 'new' }}"
@@ -59,7 +59,7 @@
     Change support status
   </a>
 
-  <ng-container *ngIf="isAccessorRole && innovation.status !== 'ARCHIVED'">
+  <ng-container *ngIf="isAccessorRole && !isArchived">
     <a routerLink="/accessor/innovations/{{ innovationId }}/support/{{ innovation.support?.id }}/request-update" class="nhsuk-button nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-3"
       >Request status update</a
     >

--- a/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.html
+++ b/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.html
@@ -8,9 +8,9 @@
 
   <p class="nhsuk-heading-s nhsuk-u-margin-bottom-4">{{ innovationSupport.organisationUnit }}</p>
   <div class="nhsuk-u-margin-bottom-8">
-    <dl class="nhsuk-summary-list nhsuk-u-margin-bottom-2" [ngClass]="isArchived ? 'border-bottom-0' : 'border-bottom-neutral'">
+    <dl class="nhsuk-summary-list nhsuk-u-margin-bottom-2">
       <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key" [ngClass]="isArchived ? 'border-bottom-0' : 'border-bottom-neutral'">Support status</dt>
+        <dt class="nhsuk-summary-list__key" [ngClass]="isArchived ? 'border-bottom-0 width-20' : 'border-bottom-neutral'">Support status</dt>
         <dd class="nhsuk-summary-list__value" [ngClass]="isArchived ? 'border-bottom-0' : 'border-bottom-neutral'">
           <theme-tag
             type="{{ 'shared.catalog.innovation.support_status.' + innovationSupport.status + '.cssColorClass' | translate }}"
@@ -45,8 +45,10 @@
         </dd>
       </div>
     </dl>
-    <p *ngIf="isArchived" class="nhsuk-u-font-size-16">Archived by innovator on {{ innovation.statusUpdatedAt | date: ("app.date_formats.long_date" | translate) }}.</p>
-    <hr class="nhsuk-section-break nhsuk-section-break--visible" />
+    <ng-container *ngIf="isArchived">
+      <p class="nhsuk-u-font-size-16">Archived by innovator on {{ innovation.statusUpdatedAt | date: ("app.date_formats.long_date" | translate) }}.</p>
+      <hr class="nhsuk-section-break nhsuk-section-break--visible" />
+    </ng-container>
   </div>
 
   <a

--- a/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.html
+++ b/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.html
@@ -18,7 +18,7 @@
       </dd>
       <dd class="nhsuk-summary-list__actions width-25">
         <a
-          *ngIf="isQualifyingAccessorRole && innovationSupport.status !== 'UNASSIGNED'"
+          *ngIf="isQualifyingAccessorRole && innovationSupport.status !== 'UNASSIGNED' && innovation.status !== 'ARCHIVED'"
           routerLink="/accessor/innovations/{{ innovationId }}/support/{{ innovation.support?.id || 'new' }}"
           >Change support status</a
         >
@@ -53,7 +53,7 @@
     Change support status
   </a>
 
-  <ng-container *ngIf="isAccessorRole">
+  <ng-container *ngIf="isAccessorRole && innovation.status !== 'ARCHIVED'">
     <a routerLink="/accessor/innovations/{{ innovationId }}/support/{{ innovation.support?.id }}/request-update" class="nhsuk-button nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-3"
       >Request status update</a
     >

--- a/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.html
+++ b/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.html
@@ -7,43 +7,49 @@
   </div>
 
   <p class="nhsuk-heading-s nhsuk-u-margin-bottom-4">{{ innovationSupport.organisationUnit }}</p>
-  <dl class="nhsuk-summary-list nhsuk-u-margin-bottom-8">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">Support status</dt>
-      <dd class="nhsuk-summary-list__value">
-        <theme-tag
-          type="{{ 'shared.catalog.innovation.support_status.' + innovationSupport.status + '.cssColorClass' | translate }}"
-          label="{{ 'shared.catalog.innovation.support_status.' + innovationSupport.status + '.name' | translate }}"
-        ></theme-tag>
-      </dd>
-      <dd class="nhsuk-summary-list__actions width-25">
-        <a
-          *ngIf="isQualifyingAccessorRole && innovationSupport.status !== 'UNASSIGNED' && innovation.status !== 'ARCHIVED'"
-          routerLink="/accessor/innovations/{{ innovationId }}/support/{{ innovation.support?.id || 'new' }}"
-          >Change support status</a
-        >
-      </dd>
-    </div>
+  <div class="nhsuk-u-margin-bottom-8">
+    <dl class="nhsuk-summary-list nhsuk-u-margin-bottom-2" [ngClass]="innovation.status === 'ARCHIVED' ? 'border-bottom-0' : 'border-bottom-neutral'">
+      <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key" [ngClass]="innovation.status === 'ARCHIVED' ? 'border-bottom-0' : 'border-bottom-neutral'">Support status</dt>
+        <dd class="nhsuk-summary-list__value" [ngClass]="innovation.status === 'ARCHIVED' ? 'border-bottom-0' : 'border-bottom-neutral'">
+          <theme-tag
+            type="{{ 'shared.catalog.innovation.support_status.' + innovationSupport.status + '.cssColorClass' | translate }}"
+            label="{{ 'shared.catalog.innovation.support_status.' + innovationSupport.status + '.name' | translate }}"
+          ></theme-tag>
+        </dd>
+        <dd *ngIf="innovation.status !== 'ARCHIVED'" class="nhsuk-summary-list__actions width-25">
+          <a
+            *ngIf="isQualifyingAccessorRole && innovationSupport.status !== 'UNASSIGNED'"
+            routerLink="/accessor/innovations/{{ innovationId }}/support/{{ innovation.support?.id || 'new' }}"
+            >Change support status</a
+          >
+        </dd>
+      </div>
 
-    <div *ngIf="innovationSupport.engagingAccessors.length > 0 || innovationSupport.status === 'ENGAGING'" class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">Assigned accessors</dt>
-      <dd class="nhsuk-summary-list__value">
-        <ul class="nhsuk-list nhsuk-u-margin-bottom-2">
-          <li *ngFor="let accessor of innovationSupport.engagingAccessors">
-            {{ accessor.name }}
-          </li>
-          <li *ngIf="innovationSupport.engagingAccessors.length === 0">No accessors assigned</li>
-        </ul>
-      </dd>
-      <dd class="nhsuk-summary-list__actions">
-        <a
-          *ngIf="isQualifyingAccessorRole && innovationSupport.status === 'ENGAGING'"
-          routerLink="/accessor/innovations/{{ innovationId }}/support/{{ innovation.support?.id || 'new' }}/change-accessors"
-          >Change accessors</a
-        >
-      </dd>
-    </div>
-  </dl>
+      <div *ngIf="innovationSupport.engagingAccessors.length > 0 || innovationSupport.status === 'ENGAGING'" class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">Assigned accessors</dt>
+        <dd class="nhsuk-summary-list__value">
+          <ul class="nhsuk-list nhsuk-u-margin-bottom-2">
+            <li *ngFor="let accessor of innovationSupport.engagingAccessors">
+              {{ accessor.name }}
+            </li>
+            <li *ngIf="innovationSupport.engagingAccessors.length === 0">No accessors assigned</li>
+          </ul>
+        </dd>
+        <dd class="nhsuk-summary-list__actions">
+          <a
+            *ngIf="isQualifyingAccessorRole && innovationSupport.status === 'ENGAGING'"
+            routerLink="/accessor/innovations/{{ innovationId }}/support/{{ innovation.support?.id || 'new' }}/change-accessors"
+            >Change accessors</a
+          >
+        </dd>
+      </div>
+    </dl>
+    <p *ngIf="innovation.status === 'ARCHIVED'" class="nhsuk-u-font-size-16">
+      Archived by innovator on {{ innovation.statusUpdatedAt | date: ("app.date_formats.long_date" | translate) }}.
+    </p>
+    <hr class="nhsuk-section-break nhsuk-section-break--visible" />
+  </div>
 
   <a
     *ngIf="isQualifyingAccessorRole && innovationSupport.status === 'UNASSIGNED'"

--- a/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.html
+++ b/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.html
@@ -8,10 +8,10 @@
 
   <p class="nhsuk-heading-s nhsuk-u-margin-bottom-4">{{ innovationSupport.organisationUnit }}</p>
   <div class="nhsuk-u-margin-bottom-8">
-    <dl class="nhsuk-summary-list nhsuk-u-margin-bottom-2" [ngClass]="innovation.status === 'ARCHIVED' ? 'border-bottom-0' : 'border-bottom-neutral'">
+    <dl class="nhsuk-summary-list nhsuk-u-margin-bottom-2" [ngClass]="isArchived ? 'border-bottom-0' : 'border-bottom-neutral'">
       <div class="nhsuk-summary-list__row">
-        <dt class="nhsuk-summary-list__key" [ngClass]="innovation.status === 'ARCHIVED' ? 'border-bottom-0' : 'border-bottom-neutral'">Support status</dt>
-        <dd class="nhsuk-summary-list__value" [ngClass]="innovation.status === 'ARCHIVED' ? 'border-bottom-0' : 'border-bottom-neutral'">
+        <dt class="nhsuk-summary-list__key" [ngClass]="isArchived ? 'border-bottom-0' : 'border-bottom-neutral'">Support status</dt>
+        <dd class="nhsuk-summary-list__value" [ngClass]="isArchived ? 'border-bottom-0' : 'border-bottom-neutral'">
           <theme-tag
             type="{{ 'shared.catalog.innovation.support_status.' + innovationSupport.status + '.cssColorClass' | translate }}"
             label="{{ 'shared.catalog.innovation.support_status.' + innovationSupport.status + '.name' | translate }}"
@@ -45,9 +45,7 @@
         </dd>
       </div>
     </dl>
-    <p *ngIf="innovation.status === 'ARCHIVED'" class="nhsuk-u-font-size-16">
-      Archived by innovator on {{ innovation.statusUpdatedAt | date: ("app.date_formats.long_date" | translate) }}.
-    </p>
+    <p *ngIf="isArchived" class="nhsuk-u-font-size-16">Archived by innovator on {{ innovation.statusUpdatedAt | date: ("app.date_formats.long_date" | translate) }}.</p>
     <hr class="nhsuk-section-break nhsuk-section-break--visible" />
   </div>
 

--- a/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.ts
@@ -114,7 +114,7 @@ export class InnovationOverviewComponent extends CoreComponent implements OnInit
       this.showCards =
         [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.WAITING].includes(
           this.innovationSupport.status
-        ) && this.innovation.status !== 'ARCHIVED';
+        ) && !this.isArchived;
 
       this.innovationCollaborators = collaborators.data;
 

--- a/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.ts
@@ -35,6 +35,7 @@ export class InnovationOverviewComponent extends CoreComponent implements OnInit
     engagingAccessors: { name: string }[];
   } = { organisationUnit: '', status: InnovationSupportStatusEnum.UNASSIGNED, engagingAccessors: [] };
 
+  isArchived: boolean = false;
   showCards: boolean = false;
 
   innovationCollaborators: InnovationCollaboratorsListDTO['data'] = [];
@@ -50,6 +51,7 @@ export class InnovationOverviewComponent extends CoreComponent implements OnInit
     this.innovation = this.stores.context.getInnovation();
     this.isQualifyingAccessorRole = this.stores.authentication.isQualifyingAccessorRole();
     this.isAccessorRole = this.stores.authentication.isAccessorRole();
+    this.isArchived = this.innovation.status === 'ARCHIVED';
 
     this.setPageTitle('Overview', { hint: `Innovation ${this.innovation.name}` });
   }

--- a/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.ts
@@ -109,9 +109,10 @@ export class InnovationOverviewComponent extends CoreComponent implements OnInit
 
       this.innovatorSummary = [{ label: 'Owner', value: this.innovation.owner?.name ?? '[deleted account]' }];
 
-      this.showCards = [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.WAITING].includes(
-        this.innovationSupport.status
-      );
+      this.showCards =
+        [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.WAITING].includes(
+          this.innovationSupport.status
+        ) && this.innovation.status !== 'ARCHIVED';
 
       this.innovationCollaborators = collaborators.data;
 

--- a/src/modules/feature-modules/admin/base/context-innovation-outlet.component.html
+++ b/src/modules/feature-modules/admin/base/context-innovation-outlet.component.html
@@ -4,5 +4,7 @@
     <a *ngIf="data.link" [routerLink]="data.link.url">{{ data.link.label }}</a>
   </div>
 
+  <theme-header-archived-banner />
+
   <hr class="nhsuk-section-break nhsuk-section-break--visible" />
 </div>

--- a/src/modules/feature-modules/admin/base/context-innovation-outlet.component.ts
+++ b/src/modules/feature-modules/admin/base/context-innovation-outlet.component.ts
@@ -27,13 +27,15 @@ export class ContextInnovationOutletComponent implements OnDestroy {
         .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
         .subscribe(e => this.onRouteChange(e))
     );
+
+    this.subscriptions.unsubscribe();
   }
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
   }
 
-  private onRouteChange(event: NavigationEnd): void {
+  private onRouteChange(event?: NavigationEnd): void {
     const innovation = this.contextStore.getInnovation();
     this.data.innovation = {
       id: innovation.id,

--- a/src/modules/feature-modules/admin/base/context-innovation-outlet.component.ts
+++ b/src/modules/feature-modules/admin/base/context-innovation-outlet.component.ts
@@ -28,7 +28,7 @@ export class ContextInnovationOutletComponent implements OnDestroy {
         .subscribe(e => this.onRouteChange(e))
     );
 
-    this.subscriptions.unsubscribe();
+    this.onRouteChange();
   }
 
   ngOnDestroy(): void {

--- a/src/modules/feature-modules/admin/pages/innovation/overview/overview.component.html
+++ b/src/modules/feature-modules/admin/pages/innovation/overview/overview.component.html
@@ -18,7 +18,7 @@
       </div>
 
       <div>
-        <div class="d-inline-block nhsuk-u-margin-bottom-4">
+        <div class="d-inline-block nhsuk-u-margin-bottom-3">
           <theme-tag
             type="{{ 'shared.catalog.innovation.grouped_status.' + innovation.groupedStatus + '.cssColorClass' | translate }}"
             label="{{ 'shared.catalog.innovation.grouped_status.' + innovation.groupedStatus + '.name' | translate }}"
@@ -36,6 +36,7 @@
           >View support status</a
         >
       </div>
+      <p>Archived by innovator on {{ innovation.statusUpdatedAt | date: ("app.date_formats.long_date" | translate) }}.</p>
     </div>
   </div>
   <hr class="nhsuk-section-break nhsuk-section-break--visible" />

--- a/src/modules/feature-modules/assessment/assessment-routing.module.ts
+++ b/src/modules/feature-modules/assessment/assessment-routing.module.ts
@@ -480,6 +480,8 @@ const routes: Routes = [
         ]
       },
 
+      { path: 'innovation-statuses', pathMatch: 'full', component: PageInnovationStatusListComponent },
+
       {
         path: 'notifications',
         pathMatch: 'full',

--- a/src/modules/feature-modules/assessment/base/context-innovation-outlet.component.html
+++ b/src/modules/feature-modules/assessment/base/context-innovation-outlet.component.html
@@ -4,5 +4,7 @@
     <a *ngIf="data.link" [routerLink]="data.link.url">{{ data.link.label }}</a>
   </div>
 
+  <theme-header-archived-banner />
+
   <hr class="nhsuk-section-break nhsuk-section-break--visible" />
 </div>

--- a/src/modules/feature-modules/assessment/base/context-innovation-outlet.component.ts
+++ b/src/modules/feature-modules/assessment/base/context-innovation-outlet.component.ts
@@ -3,7 +3,7 @@ import { NavigationEnd, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { ContextStore } from '@modules/stores';
+import { ContextInnovationType, ContextStore } from '@modules/stores';
 import { InnovationStatusEnum } from '@modules/stores/innovation/innovation.enums';
 
 @Component({
@@ -18,63 +18,69 @@ export class ContextInnovationOutletComponent implements OnDestroy {
     link: null | { label: string; url: string };
   } = { innovation: null, link: null };
 
+  innovation: ContextInnovationType;
+
   constructor(
     private router: Router,
     private contextStore: ContextStore
   ) {
+    this.innovation = this.contextStore.getInnovation();
+
     this.subscriptions.add(
       this.router.events
         .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
         .subscribe(e => this.onRouteChange(e))
     );
+
+    this.onRouteChange();
   }
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
   }
 
-  private onRouteChange(event: NavigationEnd): void {
-    const innovation = this.contextStore.getInnovation();
+  private onRouteChange(event?: NavigationEnd): void {
     this.data.innovation = {
-      id: innovation.id,
-      name: innovation.name,
-      status: innovation.status,
-      assessmentId: innovation.assessment?.id
+      id: this.innovation.id,
+      name: this.innovation.name,
+      status: this.innovation.status,
+      assessmentId: this.innovation.assessment?.id
     };
 
     // Do not show link, if ON any assessments/* route.
     if (
-      event.url.endsWith(`/assessments/new`) ||
-      event.url.endsWith(`/assessments/${innovation.assessment?.id}`) ||
-      event.url.includes(`/assessments/${innovation.assessment?.id}/edit`)
+      event &&
+      (event.url.endsWith(`/assessments/new`) ||
+        event.url.endsWith(`/assessments/${this.innovation.assessment?.id}`) ||
+        event.url.includes(`/assessments/${this.innovation.assessment?.id}/edit`))
     ) {
       this.data.link = null;
     } else {
-      switch (innovation.status) {
+      switch (this.innovation.status) {
         case InnovationStatusEnum.WAITING_NEEDS_ASSESSMENT:
-          if (!innovation.assessment?.id) {
+          if (!this.innovation.assessment?.id) {
             this.data.link = {
               label: 'Start needs assessment',
-              url: `/assessment/innovations/${innovation.id}/assessments/new`
+              url: `/assessment/innovations/${this.innovation.id}/assessments/new`
             };
           } else {
             this.data.link = {
               label: 'Continue needs assessment',
-              url: `/assessment/innovations/${innovation.id}/assessments/${innovation.assessment.id}/edit`
+              url: `/assessment/innovations/${this.innovation.id}/assessments/${this.innovation.assessment.id}/edit`
             };
           }
           break;
         case InnovationStatusEnum.NEEDS_ASSESSMENT:
           this.data.link = {
             label: 'Continue needs assessment',
-            url: `/assessment/innovations/${innovation.id}/assessments/${innovation.assessment?.id}/edit`
+            url: `/assessment/innovations/${this.innovation.id}/assessments/${this.innovation.assessment?.id}/edit`
           };
           break;
 
         case InnovationStatusEnum.IN_PROGRESS:
           this.data.link = {
             label: 'View needs assessment',
-            url: `/assessment/innovations/${innovation.id}/assessments/${innovation.assessment?.id}`
+            url: `/assessment/innovations/${this.innovation.id}/assessments/${this.innovation.assessment?.id}`
           };
           break;
 

--- a/src/modules/feature-modules/assessment/base/context-innovation-outlet.component.ts
+++ b/src/modules/feature-modules/assessment/base/context-innovation-outlet.component.ts
@@ -18,14 +18,10 @@ export class ContextInnovationOutletComponent implements OnDestroy {
     link: null | { label: string; url: string };
   } = { innovation: null, link: null };
 
-  innovation: ContextInnovationType;
-
   constructor(
     private router: Router,
     private contextStore: ContextStore
   ) {
-    this.innovation = this.contextStore.getInnovation();
-
     this.subscriptions.add(
       this.router.events
         .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
@@ -40,47 +36,49 @@ export class ContextInnovationOutletComponent implements OnDestroy {
   }
 
   private onRouteChange(event?: NavigationEnd): void {
+    const innovation = this.contextStore.getInnovation();
+
     this.data.innovation = {
-      id: this.innovation.id,
-      name: this.innovation.name,
-      status: this.innovation.status,
-      assessmentId: this.innovation.assessment?.id
+      id: innovation.id,
+      name: innovation.name,
+      status: innovation.status,
+      assessmentId: innovation.assessment?.id
     };
 
     // Do not show link, if ON any assessments/* route.
     if (
       event &&
       (event.url.endsWith(`/assessments/new`) ||
-        event.url.endsWith(`/assessments/${this.innovation.assessment?.id}`) ||
-        event.url.includes(`/assessments/${this.innovation.assessment?.id}/edit`))
+        event.url.endsWith(`/assessments/${innovation.assessment?.id}`) ||
+        event.url.includes(`/assessments/${innovation.assessment?.id}/edit`))
     ) {
       this.data.link = null;
     } else {
-      switch (this.innovation.status) {
+      switch (innovation.status) {
         case InnovationStatusEnum.WAITING_NEEDS_ASSESSMENT:
-          if (!this.innovation.assessment?.id) {
+          if (!innovation.assessment?.id) {
             this.data.link = {
               label: 'Start needs assessment',
-              url: `/assessment/innovations/${this.innovation.id}/assessments/new`
+              url: `/assessment/innovations/${innovation.id}/assessments/new`
             };
           } else {
             this.data.link = {
               label: 'Continue needs assessment',
-              url: `/assessment/innovations/${this.innovation.id}/assessments/${this.innovation.assessment.id}/edit`
+              url: `/assessment/innovations/${innovation.id}/assessments/${innovation.assessment.id}/edit`
             };
           }
           break;
         case InnovationStatusEnum.NEEDS_ASSESSMENT:
           this.data.link = {
             label: 'Continue needs assessment',
-            url: `/assessment/innovations/${this.innovation.id}/assessments/${this.innovation.assessment?.id}/edit`
+            url: `/assessment/innovations/${innovation.id}/assessments/${innovation.assessment?.id}/edit`
           };
           break;
 
         case InnovationStatusEnum.IN_PROGRESS:
           this.data.link = {
             label: 'View needs assessment',
-            url: `/assessment/innovations/${this.innovation.id}/assessments/${this.innovation.assessment?.id}`
+            url: `/assessment/innovations/${innovation.id}/assessments/${innovation.assessment?.id}`
           };
           break;
 

--- a/src/modules/feature-modules/assessment/pages/innovation/overview/overview.component.html
+++ b/src/modules/feature-modules/assessment/pages/innovation/overview/overview.component.html
@@ -68,7 +68,7 @@
     </ng-container>
   </ng-container>
 
-  <ng-container *ngIf="innovation?.status && innovation?.status !== 'WAITING_NEEDS_ASSESSMENT'">
+  <ng-container *ngIf="showCards">
     <app-statistics-cards [cardsList]="cardsList" [gridClass]="'nhsuk-grid-column-one-half'"></app-statistics-cards>
   </ng-container>
 

--- a/src/modules/feature-modules/assessment/pages/innovation/overview/overview.component.html
+++ b/src/modules/feature-modules/assessment/pages/innovation/overview/overview.component.html
@@ -66,6 +66,41 @@
         </div>
       </dl>
     </ng-container>
+
+    <ng-container *ngSwitchCase="'ARCHIVED'">
+      <div class="d-flex">
+        <theme-svg-icon type="success"></theme-svg-icon>
+        <span class="nhsuk-u-margin-right-2"></span>
+        <h2 class="nhsuk-heading-m">
+          {{ innovation?.assessment?.reassessmentCount ? "Needs reassessment complete" : "Needs assessment complete" }}
+        </h2>
+      </div>
+
+      <hr class="nhsuk-section-break nhsuk-section-break--visible" />
+      <dl class="nhsuk-summary-list">
+        <ng-container *ngTemplateOutlet="exemptionTemplate; context: { exemption: assessmentExemption }"></ng-container>
+        <div class="nhsuk-summary-list__row">
+          <dt class="nhsuk-summary-list__key">Assigned assessor</dt>
+          <dd class="nhsuk-summary-list__value">{{ innovation?.assessment?.assignedTo?.name }}</dd>
+          <dd class="nhsuk-summary-list__actions width-30"></dd>
+        </div>
+        <div class="nhsuk-summary-list__row">
+          <dt class="nhsuk-summary-list__key">Support status</dt>
+          <dd class="nhsuk-summary-list__value">
+            <theme-tag
+              type="{{ 'shared.catalog.innovation.grouped_status.' + innovation?.status + '.cssColorClass' | translate }}"
+              label="{{ 'shared.catalog.innovation.grouped_status.' + innovation?.status + '.name' | translate }}"
+            ></theme-tag>
+            <p class="font-color-secondary nhsuk-body-s nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-2">
+              Archived on {{ innovation?.statusUpdatedAt | date: ("app.date_formats.long_date" | translate) }}.
+            </p>
+          </dd>
+          <dd class="nhsuk-summary-list__actions width-30 nhsuk-u-font-size-16">
+            <a routerLink="/assessment/innovation-statuses" arial-label="View innovation status information">What does this status mean?</a>
+          </dd>
+        </div>
+      </dl>
+    </ng-container>
   </ng-container>
 
   <ng-container *ngIf="showCards">

--- a/src/modules/feature-modules/assessment/pages/innovation/overview/overview.component.ts
+++ b/src/modules/feature-modules/assessment/pages/innovation/overview/overview.component.ts
@@ -28,6 +28,7 @@ export class InnovationOverviewComponent extends CoreComponent implements OnInit
   innovationId: string;
   innovation: null | InnovationInfoDTO = null;
 
+  isArchived: boolean = false;
   showCards: boolean = true;
 
   assessmentExemption: null | Required<AssessmentExemptionTypeDTO>['exemption'] = null;
@@ -65,6 +66,8 @@ export class InnovationOverviewComponent extends CoreComponent implements OnInit
       .pipe(
         switchMap(innovationInfo => {
           this.innovation = innovationInfo;
+
+          this.isArchived = this.innovation.status === 'ARCHIVED';
 
           this.showCards = ![InnovationStatusEnum.ARCHIVED, InnovationStatusEnum.WAITING_NEEDS_ASSESSMENT].includes(
             this.innovation.status

--- a/src/modules/feature-modules/assessment/pages/innovation/overview/overview.component.ts
+++ b/src/modules/feature-modules/assessment/pages/innovation/overview/overview.component.ts
@@ -102,20 +102,25 @@ export class InnovationOverviewComponent extends CoreComponent implements OnInit
             }
           ];
 
+          const isArchived = this.innovation.status === 'ARCHIVED';
           this.innovatorSummary = [
             { label: 'Owner', value: this.innovation.owner?.name ?? '[deleted account]' },
             {
               label: 'Contact preference',
-              value:
-                UtilsHelper.getContactPreferenceValue(
-                  this.innovation.owner?.contactByEmail,
-                  this.innovation.owner?.contactByPhone,
-                  this.innovation.owner?.contactByPhoneTimeframe
-                ) || ''
+              value: isArchived
+                ? 'Not available'
+                : UtilsHelper.getContactPreferenceValue(
+                    this.innovation.owner?.contactByEmail,
+                    this.innovation.owner?.contactByPhone,
+                    this.innovation.owner?.contactByPhoneTimeframe
+                  ) || ''
             },
-            { label: 'Contact details', value: this.innovation.owner?.contactDetails || '' },
-            { label: 'Email address', value: this.innovation.owner?.email || '' },
-            { label: 'Phone number', value: this.innovation.owner?.mobilePhone || '' }
+            {
+              label: 'Contact details',
+              value: isArchived ? 'Not available' : this.innovation.owner?.contactDetails || ''
+            },
+            { label: 'Email address', value: isArchived ? 'Not available' : this.innovation.owner?.email || '' },
+            { label: 'Phone number', value: isArchived ? 'Not available' : this.innovation.owner?.mobilePhone || '' }
           ];
 
           return forkJoin([

--- a/src/modules/feature-modules/assessment/pages/innovation/overview/overview.component.ts
+++ b/src/modules/feature-modules/assessment/pages/innovation/overview/overview.component.ts
@@ -105,12 +105,11 @@ export class InnovationOverviewComponent extends CoreComponent implements OnInit
             }
           ];
 
-          const isArchived = this.innovation.status === 'ARCHIVED';
           this.innovatorSummary = [
             { label: 'Owner', value: this.innovation.owner?.name ?? '[deleted account]' },
             {
               label: 'Contact preference',
-              value: isArchived
+              value: this.isArchived
                 ? 'Not available'
                 : UtilsHelper.getContactPreferenceValue(
                     this.innovation.owner?.contactByEmail,
@@ -120,10 +119,13 @@ export class InnovationOverviewComponent extends CoreComponent implements OnInit
             },
             {
               label: 'Contact details',
-              value: isArchived ? 'Not available' : this.innovation.owner?.contactDetails || ''
+              value: this.isArchived ? 'Not available' : this.innovation.owner?.contactDetails || ''
             },
-            { label: 'Email address', value: isArchived ? 'Not available' : this.innovation.owner?.email || '' },
-            { label: 'Phone number', value: isArchived ? 'Not available' : this.innovation.owner?.mobilePhone || '' }
+            { label: 'Email address', value: this.isArchived ? 'Not available' : this.innovation.owner?.email || '' },
+            {
+              label: 'Phone number',
+              value: this.isArchived ? 'Not available' : this.innovation.owner?.mobilePhone || ''
+            }
           ];
 
           return forkJoin([

--- a/src/modules/feature-modules/assessment/pages/innovation/overview/overview.component.ts
+++ b/src/modules/feature-modules/assessment/pages/innovation/overview/overview.component.ts
@@ -18,6 +18,7 @@ import {
   AssessmentExemptionTypeDTO,
   AssessmentService
 } from '@modules/feature-modules/assessment/services/assessment.service';
+import { InnovationStatusEnum } from '@modules/stores/innovation';
 
 @Component({
   selector: 'app-assessment-pages-innovation-overview',
@@ -26,6 +27,8 @@ import {
 export class InnovationOverviewComponent extends CoreComponent implements OnInit {
   innovationId: string;
   innovation: null | InnovationInfoDTO = null;
+
+  showCards: boolean = true;
 
   assessmentExemption: null | Required<AssessmentExemptionTypeDTO>['exemption'] = null;
   innovationSummary: { label: string; value: null | string }[] = [];
@@ -62,6 +65,10 @@ export class InnovationOverviewComponent extends CoreComponent implements OnInit
       .pipe(
         switchMap(innovationInfo => {
           this.innovation = innovationInfo;
+
+          this.showCards = ![InnovationStatusEnum.ARCHIVED, InnovationStatusEnum.WAITING_NEEDS_ASSESSMENT].includes(
+            this.innovation.status
+          );
 
           this.setPageTitle('Overview', { hint: `Innovation ${this.innovation.name}` });
 

--- a/src/modules/feature-modules/innovator/base/context-innovation-outlet.component.html
+++ b/src/modules/feature-modules/innovator/base/context-innovation-outlet.component.html
@@ -4,15 +4,7 @@
     <p class="nhsuk-caption-m nhsuk-u-margin-0">{{ innovation.userIsOwner ? "Innovation owner" : "Innovation collaborator" }}</p>
   </div>
 
-  <div *ngIf="showArchivedBanner" class="nhsuk-card d-flex flex-direction-column nhsuk-u-padding-5 nhsuk-u-font-size-19">
-    <span>
-      <strong>This innovation was archived on {{ innovation.statusUpdatedAt | date: ("app.date_formats.long_date" | translate) }}</strong>
-    </span>
-    <span>
-      You can continue to update your innovation record when it is archived. These changes can only be viewed by you and your collaborators. If you want support on your innovation
-      in future, you can submit your record for a needs reassessment.
-    </span>
-  </div>
+  <theme-header-archived-banner />
 
   <hr class="nhsuk-section-break nhsuk-section-break--visible" />
 </div>

--- a/src/modules/feature-modules/innovator/base/context-innovation-outlet.component.ts
+++ b/src/modules/feature-modules/innovator/base/context-innovation-outlet.component.ts
@@ -3,9 +3,7 @@ import { NavigationEnd, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { AuthenticationStore, ContextStore } from '@modules/stores';
-import { DateISOType } from '@app/base/types';
-import { InnovationStatusEnum } from '@modules/stores/innovation';
+import { ContextStore } from '@modules/stores';
 
 @Component({
   selector: 'app-base-context-innovation-outlet',
@@ -18,22 +16,20 @@ export class ContextInnovationOutletComponent implements OnDestroy {
     id: string;
     name: string;
     userIsOwner: boolean;
-    statusUpdatedAt: null | DateISOType;
-  } = { id: '', name: '', userIsOwner: false, statusUpdatedAt: null };
+  } = { id: '', name: '', userIsOwner: false };
 
   showArchivedBanner: boolean = false;
+  currentUrl: string = '';
 
   constructor(
     private router: Router,
-    private contextStore: ContextStore,
-    private authentication: AuthenticationStore
+    private contextStore: ContextStore
   ) {
     this.subscriptions.add(
       this.router.events
         .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
         .subscribe(e => this.onRouteChange(e))
     );
-
     this.onRouteChange();
   }
 
@@ -46,16 +42,7 @@ export class ContextInnovationOutletComponent implements OnDestroy {
     this.innovation = {
       id: innovation.id,
       name: innovation.name,
-      userIsOwner: innovation.loggedUser.isOwner,
-      statusUpdatedAt: innovation.statusUpdatedAt
+      userIsOwner: innovation.loggedUser.isOwner
     };
-
-    const baseUrl = `${this.authentication.userUrlBasePath()}/innovations/${innovation.id}`;
-
-    // Regex to check for all 'root' innovation's pages only (i.e.: '/overview', 'tasks'), while children are ignored (i.e: 'thread/:id', 'record/sections/:sectionId', etc.). 'manage' endpoint is an exception, since it redirects to '/manage/innovation'
-    const pageRootCheckRegex = new RegExp(`(${baseUrl.replace(/\//g, '\\/')}\/)(manage\/innovation?|[a-zA-Z-]*)$`);
-
-    this.showArchivedBanner =
-      this.contextStore.getInnovation().status === 'ARCHIVED' && pageRootCheckRegex.test(this.router.url);
   }
 }

--- a/src/modules/feature-modules/innovator/base/context-innovation-outlet.component.ts
+++ b/src/modules/feature-modules/innovator/base/context-innovation-outlet.component.ts
@@ -18,9 +18,6 @@ export class ContextInnovationOutletComponent implements OnDestroy {
     userIsOwner: boolean;
   } = { id: '', name: '', userIsOwner: false };
 
-  showArchivedBanner: boolean = false;
-  currentUrl: string = '';
-
   constructor(
     private router: Router,
     private contextStore: ContextStore

--- a/src/modules/shared/pages/innovation/assessment/assessment-overview.component.html
+++ b/src/modules/shared/pages/innovation/assessment/assessment-overview.component.html
@@ -135,7 +135,7 @@
       <ng-container *ngIf="isAccessorType">
         <a routerLink="/accessor/innovations/{{ innovationId }}" class="nhsuk-button nhsuk-u-margin-top-5 nhsuk-u-margin-right-3">Continue to innovation</a>
         <a
-          *ngIf="isQualifyingAccessorRole"
+          *ngIf="isQualifyingAccessorRole && innovation.status !== 'ARCHIVED'"
           routerLink="/accessor/innovations/{{ innovationId }}/support/{{ innovation.support?.id || 'new' }}"
           class="nhsuk-button nhsuk-u-margin-top-5 nhsuk-button--secondary"
         >

--- a/src/modules/shared/pages/innovation/assessment/assessment-overview.component.html
+++ b/src/modules/shared/pages/innovation/assessment/assessment-overview.component.html
@@ -125,7 +125,7 @@
       <ng-container *ngIf="isAssessmentType">
         <a routerLink="/assessment/innovations/{{ innovationId }}" class="nhsuk-button nhsuk-u-margin-top-5 nhsuk-u-margin-right-3">Continue to innovation</a>
         <a
-          *ngIf="innovation.status !== 'ARCHIVED'"
+          *ngIf="!isArchived"
           routerLink="/assessment/innovations/{{ innovationId }}/assessments/{{ assessmentId }}/edit"
           class="nhsuk-button nhsuk-u-margin-top-5 nhsuk-button--secondary"
           >Edit assessment</a
@@ -135,7 +135,7 @@
       <ng-container *ngIf="isAccessorType">
         <a routerLink="/accessor/innovations/{{ innovationId }}" class="nhsuk-button nhsuk-u-margin-top-5 nhsuk-u-margin-right-3">Continue to innovation</a>
         <a
-          *ngIf="isQualifyingAccessorRole && innovation.status !== 'ARCHIVED'"
+          *ngIf="isQualifyingAccessorRole && !isArchived"
           routerLink="/accessor/innovations/{{ innovationId }}/support/{{ innovation.support?.id || 'new' }}"
           class="nhsuk-button nhsuk-u-margin-top-5 nhsuk-button--secondary"
         >

--- a/src/modules/shared/pages/innovation/assessment/assessment-overview.component.html
+++ b/src/modules/shared/pages/innovation/assessment/assessment-overview.component.html
@@ -124,7 +124,10 @@
 
       <ng-container *ngIf="isAssessmentType">
         <a routerLink="/assessment/innovations/{{ innovationId }}" class="nhsuk-button nhsuk-u-margin-top-5 nhsuk-u-margin-right-3">Continue to innovation</a>
-        <a routerLink="/assessment/innovations/{{ innovationId }}/assessments/{{ assessmentId }}/edit" class="nhsuk-button nhsuk-u-margin-top-5 nhsuk-button--secondary"
+        <a
+          *ngIf="innovation.status !== 'ARCHIVED'"
+          routerLink="/assessment/innovations/{{ innovationId }}/assessments/{{ assessmentId }}/edit"
+          class="nhsuk-button nhsuk-u-margin-top-5 nhsuk-button--secondary"
           >Edit assessment</a
         >
       </ng-container>

--- a/src/modules/shared/pages/innovation/assessment/assessment-overview.component.ts
+++ b/src/modules/shared/pages/innovation/assessment/assessment-overview.component.ts
@@ -40,6 +40,8 @@ export class PageInnovationAssessmentOverviewComponent extends CoreComponent imp
   isInnovatorType: boolean;
   isQualifyingAccessorRole: boolean;
 
+  isArchived: boolean;
+
   assessmentHasBeenSubmitted = false;
   shouldShowUpdatedAt = false;
 
@@ -58,6 +60,8 @@ export class PageInnovationAssessmentOverviewComponent extends CoreComponent imp
     this.isAccessorType = this.stores.authentication.isAccessorType();
     this.isInnovatorType = this.stores.authentication.isInnovatorType();
     this.isQualifyingAccessorRole = this.isAccessorType && this.stores.authentication.isQualifyingAccessorRole();
+
+    this.isArchived = this.innovation.status === 'ARCHIVED';
   }
 
   ngOnInit(): void {

--- a/src/modules/shared/pages/innovation/status/innovation-status-list.component.ts
+++ b/src/modules/shared/pages/innovation/status/innovation-status-list.component.ts
@@ -25,5 +25,9 @@ export class PageInnovationStatusListComponent extends CoreComponent {
     this.setPageTitle('Innovation status key');
     this.setBackLink('Go back');
     this.setPageStatus('READY');
+
+    if (this.stores.authentication.isAssessmentType()) {
+      this.visibleStatus = this.visibleStatus.filter(status => status === InnovationGroupedStatusEnum.ARCHIVED);
+    }
   }
 }

--- a/src/modules/theme/components/header/header-archived-banner.component.html
+++ b/src/modules/theme/components/header/header-archived-banner.component.html
@@ -1,9 +1,22 @@
-<div *ngIf="showArchivedBanner" class="nhsuk-card d-flex flex-direction-column nhsuk-u-padding-5 nhsuk-u-font-size-19">
-  <span>
-    <strong>This innovation was archived on {{ statusUpdatedAt | date: ("app.date_formats.long_date" | translate) }}</strong>
-  </span>
-  <span>
-    You can continue to update your innovation record when it is archived. These changes can only be viewed by you and your collaborators. If you want support on your innovation in
-    future, you can submit your record for a needs reassessment.
-  </span>
-</div>
+<ng-container *ngIf="innovation.status === 'ARCHIVED' && showBanner">
+  <div *ngIf="!isInnovator; else innovatorBanner" class="nhsuk-card d-flex flex-direction-column nhsuk-u-padding-5 nhsuk-u-font-size-19">
+    <span>
+      <strong>This innovation was archived by the innovator on {{ innovation.statusUpdatedAt | date: ("app.date_formats.long_date" | translate) }}.</strong>
+    </span>
+    <span>
+      You can view an archived version of the innovation record, support summary, tasks, messages, and documents. All open tasks have been cancelled. You cannot reply to
+      messages.</span
+    >
+  </div>
+  <ng-template #innovatorBanner>
+    <div class="nhsuk-card d-flex flex-direction-column nhsuk-u-padding-5 nhsuk-u-font-size-19">
+      <span>
+        <strong>This innovation was archived on {{ innovation.statusUpdatedAt | date: ("app.date_formats.long_date" | translate) }}.</strong>
+      </span>
+      <span>
+        You can continue to update your innovation record when it is archived. These changes can only be viewed by you and your collaborators. If you want support on your
+        innovation in future, you can submit your record for a needs reassessment.
+      </span>
+    </div>
+  </ng-template>
+</ng-container>

--- a/src/modules/theme/components/header/header-archived-banner.component.html
+++ b/src/modules/theme/components/header/header-archived-banner.component.html
@@ -1,0 +1,9 @@
+<div *ngIf="showArchivedBanner" class="nhsuk-card d-flex flex-direction-column nhsuk-u-padding-5 nhsuk-u-font-size-19">
+  <span>
+    <strong>This innovation was archived on {{ statusUpdatedAt | date: ("app.date_formats.long_date" | translate) }}</strong>
+  </span>
+  <span>
+    You can continue to update your innovation record when it is archived. These changes can only be viewed by you and your collaborators. If you want support on your innovation in
+    future, you can submit your record for a needs reassessment.
+  </span>
+</div>

--- a/src/modules/theme/components/header/header-archived-banner.component.ts
+++ b/src/modules/theme/components/header/header-archived-banner.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { DateISOType } from '@app/base/types';
+
+@Component({
+  selector: 'theme-header-archived-banner',
+  templateUrl: './header-archived-banner.component.html'
+})
+export class HeaderArchivedBannerComponent implements OnInit {
+  @Input() statusUpdatedAt: DateISOType;
+
+  constructor() {}
+}

--- a/src/modules/theme/components/header/header-archived-banner.component.ts
+++ b/src/modules/theme/components/header/header-archived-banner.component.ts
@@ -1,8 +1,7 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
-import { ContextInnovationType, DateISOType } from '@app/base/types';
+import { ContextInnovationType } from '@app/base/types';
 import { AuthenticationStore, ContextStore } from '@modules/stores';
-import { InnovationStatusEnum } from '@modules/stores/innovation';
 import { filter } from 'rxjs';
 
 @Component({
@@ -10,7 +9,7 @@ import { filter } from 'rxjs';
   templateUrl: './header-archived-banner.component.html'
 })
 export class HeaderArchivedBannerComponent implements OnInit {
-  showBanner: boolean = false;
+  showBanner: boolean = true;
   baseUrl: string = '';
   regEx: RegExp = RegExp('');
   isInnovator: boolean;
@@ -25,6 +24,7 @@ export class HeaderArchivedBannerComponent implements OnInit {
     this.innovation = this.context.getInnovation();
     this.baseUrl = `${this.authentication.userUrlBasePath()}/innovations/${this.innovation.id}`;
     this.regEx = new RegExp(`(${this.baseUrl.replace(/\//g, '\\/')}\/)(manage\/innovation?|[a-zA-Z-]*)$`);
+
     this.router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)).subscribe(e => {
       this.showBanner = this.regEx.test(this.router.url);
     });

--- a/src/modules/theme/components/header/header-archived-banner.component.ts
+++ b/src/modules/theme/components/header/header-archived-banner.component.ts
@@ -1,12 +1,35 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { DateISOType } from '@app/base/types';
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { ContextInnovationType, DateISOType } from '@app/base/types';
+import { AuthenticationStore, ContextStore } from '@modules/stores';
+import { InnovationStatusEnum } from '@modules/stores/innovation';
+import { filter } from 'rxjs';
 
 @Component({
   selector: 'theme-header-archived-banner',
   templateUrl: './header-archived-banner.component.html'
 })
 export class HeaderArchivedBannerComponent implements OnInit {
-  @Input() statusUpdatedAt: DateISOType;
+  showBanner: boolean = false;
+  baseUrl: string = '';
+  regEx: RegExp = RegExp('');
+  isInnovator: boolean;
+  innovation: ContextInnovationType;
 
-  constructor() {}
+  constructor(
+    private router: Router,
+    private authentication: AuthenticationStore,
+    private context: ContextStore
+  ) {
+    this.isInnovator = this.authentication.isInnovatorType();
+    this.innovation = this.context.getInnovation();
+    this.baseUrl = `${this.authentication.userUrlBasePath()}/innovations/${this.innovation.id}`;
+    this.regEx = new RegExp(`(${this.baseUrl.replace(/\//g, '\\/')}\/)(manage\/innovation?|[a-zA-Z-]*)$`);
+    this.router.events.pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd)).subscribe(e => {
+      this.showBanner = this.regEx.test(this.router.url);
+    });
+  }
+  ngOnInit(): void {
+    this.showBanner = this.regEx.test(this.router.url);
+  }
 }

--- a/src/modules/theme/theme.module.ts
+++ b/src/modules/theme/theme.module.ts
@@ -39,6 +39,7 @@ import { TagComponent } from './components/tag/tag.component';
 import { InnovationAdvancedSearchCardComponent } from '@modules/shared/pages/innovations/innovation-advanced-search-card.component';
 import { SelectComponent } from './components/search/select.component';
 import { FormsModule } from '@angular/forms';
+import { HeaderArchivedBannerComponent } from './components/header/header-archived-banner.component';
 
 @NgModule({
   imports: [
@@ -88,7 +89,9 @@ import { FormsModule } from '@angular/forms';
 
     InnovationAdvancedSearchCardComponent,
 
-    SelectComponent
+    SelectComponent,
+
+    HeaderArchivedBannerComponent
   ],
   providers: [],
   exports: [
@@ -130,7 +133,9 @@ import { FormsModule } from '@angular/forms';
 
     SelectComponent,
 
-    InnovationAdvancedSearchCardComponent
+    InnovationAdvancedSearchCardComponent,
+
+    HeaderArchivedBannerComponent
   ]
 })
 export class ThemeModule {}


### PR DESCRIPTION
Closes [AB#161641](https://dev.azure.com/NHSiDev/InnovatorService/_workitems/edit/161641)

- Passed code for 'archived' banner to its own component, in order to be reused for all users.
- Updated rules for several buttons/action links for QA/A/Na/Admin.
- Since we are now displaying the 'Archived' status on the Overview page for NAs, added 'support statuses' page with only 'Archived' status's description.

Screenshots:

-QA / A:
![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/4017664/a1410e70-bf44-4b33-95a6-d9225385adf0)

-Admin:
![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/4017664/15ff8e72-0b29-427a-8ccf-462d5e22cf4a)

-NA:
![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/4017664/d3e62137-3d73-4250-8f1f-526565ca37aa)
![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/4017664/23705759-02db-45f3-9abe-37388e8673e6)
![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/4017664/0e67c6cb-807d-4f98-a433-0370d929c657)



