### PR TITLE
feat: add archived filter to na innovation list

### DIFF
--- a/src/modules/feature-modules/assessment/pages/innovations/innovations-list.component.html
+++ b/src/modules/feature-modules/assessment/pages/innovations/innovations-list.component.html
@@ -6,7 +6,7 @@
         <a routerLink="/assessment/innovations" [queryParams]="{ status: 'COMPLETED' }">innovations with needs assessment completed</a>.
       </p>
       <ng-template #completedLeadDescription>
-        <p>Needs assessment has been completed for these innovations. They are visible to all organisations that the innovator choose to share their data with.</p>
+        <p>Needs assessment is complete for these innovations. They are visible to all organisations that the innovator has chosen to share their data with.</p>
       </ng-template>
     </div>
 

--- a/src/modules/feature-modules/assessment/pages/innovations/innovations-list.component.ts
+++ b/src/modules/feature-modules/assessment/pages/innovations/innovations-list.component.ts
@@ -151,12 +151,13 @@ export class InnovationsListComponent extends CoreComponent implements OnInit {
         switch (status) {
           case 'COMPLETED':
             this.showOnlyCompleted = true;
-            this.setPageTitle('Assessment completed innovations');
+            this.setPageTitle('Needs assessment complete');
             this.setBackLink('Go back', `${this.userUrlBasePath()}/innovations`);
             this.availableGroupedStatus = [
               InnovationGroupedStatusEnum.AWAITING_SUPPORT,
               InnovationGroupedStatusEnum.RECEIVING_SUPPORT,
-              InnovationGroupedStatusEnum.NO_ACTIVE_SUPPORT
+              InnovationGroupedStatusEnum.NO_ACTIVE_SUPPORT,
+              InnovationGroupedStatusEnum.ARCHIVED
             ];
             break;
           case 'NEEDS_ASSESSMENT':


### PR DESCRIPTION
**Description:**
- Allow NAs to see archived innovations on their innovations lists by adding a new filter for `ARCHIVED` innovations.

**Screenshot:**
![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/115171210/90b28480-6051-48ca-ad7e-4d2b6a0656b7)
