### PR TITLE
Archived innovation: impacts on innovation record page

### DIFF
--- a/src/modules/feature-modules/accessor/accessor-routing.module.ts
+++ b/src/modules/feature-modules/accessor/accessor-routing.module.ts
@@ -48,7 +48,7 @@ import { PageInnovationThreadMessagesListComponent } from '@modules/shared/pages
 import { PageInnovationThreadsListComponent } from '@modules/shared/pages/innovation/messages/threads-list.component';
 import { WizardInnovationThreadNewComponent } from '@modules/shared/pages/innovation/messages/wizard-thread-new/thread-new.component';
 import { PageInnovationRecordDownloadComponent } from '@modules/shared/pages/innovation/record/innovation-record-download.component';
-import { PageInnovationRecordComponent } from '@modules/shared/pages/innovation/record/innovation-record.component';
+import { PageInnovationRecordWrapperComponent } from '@modules/shared/pages/innovation/record/innovation-record-wrapper.component';
 import { PageInnovationSectionEvidenceInfoComponent } from '@modules/shared/pages/innovation/sections/section-evidence-info.component';
 import { PageInnovationSectionInfoComponent } from '@modules/shared/pages/innovation/sections/section-info.component';
 import { PageInnovationSupportStatusListComponent } from '@modules/shared/pages/innovation/support/support-status-list.component';
@@ -170,7 +170,12 @@ const routes: Routes = [
                 path: 'record',
                 data: { breadcrumb: 'Innovation record' },
                 children: [
-                  { path: '', pathMatch: 'full', component: PageInnovationRecordComponent, data: { breadcrumb: null } },
+                  {
+                    path: '',
+                    pathMatch: 'full',
+                    component: PageInnovationRecordWrapperComponent,
+                    data: { breadcrumb: null }
+                  },
 
                   {
                     path: 'download',

--- a/src/modules/feature-modules/accessor/base/sidebar-innovation-menu-outlet.component.html
+++ b/src/modules/feature-modules/accessor/base/sidebar-innovation-menu-outlet.component.html
@@ -30,6 +30,6 @@
       </ul>
     </li>
   </ul>
-
-  <theme-go-to-top-link />
 </ng-container>
+
+<theme-go-to-top-link *ngIf="isAllSectionsDetailsPage || (isInnovationRecordPage && isInnovationInArchivedStatus)" />

--- a/src/modules/feature-modules/accessor/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/accessor/base/sidebar-innovation-menu-outlet.component.ts
@@ -18,6 +18,8 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
   navHeading: string = 'Innovation Record sections';
   showHeading: boolean = false;
   isAllSectionsDetailsPage: boolean = false;
+  isInnovationRecordPage: boolean = false;
+  isInnovationInArchivedStatus: boolean = false;
 
   private sectionsSidebar: { label: string; url: string; children?: { label: string; id: string; url: string }[] }[] =
     [];
@@ -73,6 +75,9 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
     this.generateSidebar();
 
     this.isAllSectionsDetailsPage = this.router.url.includes('/all');
+    this.isInnovationRecordPage = this.router.url.endsWith('/record');
+
+    this.isInnovationInArchivedStatus = this.contextStore.getInnovation().status === InnovationStatusEnum.ARCHIVED;
 
     if (this.router.url.includes('sections')) {
       this.showHeading = true;

--- a/src/modules/feature-modules/admin/admin-routing.module.ts
+++ b/src/modules/feature-modules/admin/admin-routing.module.ts
@@ -52,7 +52,7 @@ import { PageInnovationDocumentsListComponent } from '@modules/shared/pages/inno
 import { PageEveryoneWorkingOnInnovationComponent } from '@modules/shared/pages/innovation/everyone-working-on-innovation/everyone-working-on-innovation.component';
 import { PageInnovationThreadMessagesListComponent } from '@modules/shared/pages/innovation/messages/thread-messages-list.component';
 import { PageInnovationThreadsListComponent } from '@modules/shared/pages/innovation/messages/threads-list.component';
-import { PageInnovationRecordComponent } from '@modules/shared/pages/innovation/record/innovation-record.component';
+import { PageInnovationRecordWrapperComponent } from '@modules/shared/pages/innovation/record/innovation-record-wrapper.component';
 import { PageInnovationSectionEvidenceInfoComponent } from '@modules/shared/pages/innovation/sections/section-evidence-info.component';
 import { PageInnovationSectionInfoComponent } from '@modules/shared/pages/innovation/sections/section-info.component';
 import { PageInnovationStatusListComponent } from '@modules/shared/pages/innovation/status/innovation-status-list.component';
@@ -395,7 +395,7 @@ const routes: Routes = [
                   {
                     path: '',
                     pathMatch: 'full',
-                    component: PageInnovationRecordComponent,
+                    component: PageInnovationRecordWrapperComponent,
                     data: { breadcrumb: null }
                   },
 

--- a/src/modules/feature-modules/admin/base/sidebar-innovation-menu-outlet.component.html
+++ b/src/modules/feature-modules/admin/base/sidebar-innovation-menu-outlet.component.html
@@ -11,3 +11,5 @@
     </ul>
   </li>
 </ul>
+
+<theme-go-to-top-link *ngIf="isInnovationRecordPage && isInnovationInArchivedStatus" />

--- a/src/modules/feature-modules/admin/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/admin/base/sidebar-innovation-menu-outlet.component.ts
@@ -16,6 +16,8 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
   sidebarItems: { label: string; url: string; children?: { label: string; url: string }[] }[] = [];
   navHeading: string = 'Innovation Record sections';
   showHeading: boolean = false;
+  isInnovationRecordPage: boolean = false;
+  isInnovationInArchivedStatus: boolean = false;
 
   private sectionsSidebar: { label: string; url: string; children?: { label: string; url: string }[] }[] = [];
   private _sidebarItems: { label: string; url: string }[] = [];
@@ -70,6 +72,10 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
 
   private onRouteChange(): void {
     this.generateSidebar();
+
+    this.isInnovationRecordPage = this.router.url.endsWith('/record');
+
+    this.isInnovationInArchivedStatus = this.contextStore.getInnovation().status === InnovationStatusEnum.ARCHIVED;
 
     if (this.router.url.includes('sections')) {
       this.showHeading = true;

--- a/src/modules/feature-modules/assessment/assessment-routing.module.ts
+++ b/src/modules/feature-modules/assessment/assessment-routing.module.ts
@@ -48,7 +48,7 @@ import { PageInnovationThreadMessagesListComponent } from '@modules/shared/pages
 import { PageInnovationThreadsListComponent } from '@modules/shared/pages/innovation/messages/threads-list.component';
 import { WizardInnovationThreadNewComponent } from '@modules/shared/pages/innovation/messages/wizard-thread-new/thread-new.component';
 import { PageInnovationRecordDownloadComponent } from '@modules/shared/pages/innovation/record/innovation-record-download.component';
-import { PageInnovationRecordComponent } from '@modules/shared/pages/innovation/record/innovation-record.component';
+import { PageInnovationRecordWrapperComponent } from '@modules/shared/pages/innovation/record/innovation-record-wrapper.component';
 import { PageInnovationSectionEvidenceInfoComponent } from '@modules/shared/pages/innovation/sections/section-evidence-info.component';
 import { PageInnovationSectionInfoComponent } from '@modules/shared/pages/innovation/sections/section-info.component';
 import { PageInnovationStatusListComponent } from '@modules/shared/pages/innovation/status/innovation-status-list.component';
@@ -202,7 +202,12 @@ const routes: Routes = [
                 path: 'record',
                 data: { breadcrumb: 'Innovation record' },
                 children: [
-                  { path: '', pathMatch: 'full', component: PageInnovationRecordComponent, data: { breadcrumb: null } },
+                  {
+                    path: '',
+                    pathMatch: 'full',
+                    component: PageInnovationRecordWrapperComponent,
+                    data: { breadcrumb: null }
+                  },
 
                   {
                     path: 'download',

--- a/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.html
+++ b/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.html
@@ -30,6 +30,6 @@
       </ul>
     </li>
   </ul>
-
-  <theme-go-to-top-link />
 </ng-container>
+
+<theme-go-to-top-link *ngIf="isAllSectionsDetailsPage || (isInnovationRecordPage && isInnovationInArchivedStatus)" />

--- a/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.ts
@@ -18,6 +18,8 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
   navHeading: string = 'Innovation Record sections';
   showHeading: boolean = false;
   isAllSectionsDetailsPage: boolean = false;
+  isInnovationRecordPage: boolean = false;
+  isInnovationInArchivedStatus: boolean = false;
 
   private sectionsSidebar: { label: string; url: string; children?: { label: string; id: string; url: string }[] }[] =
     [];
@@ -76,6 +78,9 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
     this.generateSidebar();
 
     this.isAllSectionsDetailsPage = this.router.url.includes('/all');
+    this.isInnovationRecordPage = this.router.url.endsWith('/record');
+
+    this.isInnovationInArchivedStatus = this.contextStore.getInnovation().status === InnovationStatusEnum.ARCHIVED;
 
     if (this.router.url.includes('sections')) {
       this.showHeading = true;

--- a/src/modules/shared/pages/innovation/record/innovation-record-wrapper.component.html
+++ b/src/modules/shared/pages/innovation/record/innovation-record-wrapper.component.html
@@ -1,0 +1,3 @@
+<shared-pages-innovation-record *ngIf="!showAllSectionsInfo" />
+
+<shared-pages-innovation-all-sections-info *ngIf="showAllSectionsInfo" />

--- a/src/modules/shared/pages/innovation/record/innovation-record-wrapper.component.ts
+++ b/src/modules/shared/pages/innovation/record/innovation-record-wrapper.component.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { CoreComponent } from '@app/base';
+import { ContextInnovationType } from '@modules/stores';
+import { InnovationStatusEnum } from '@modules/stores/innovation';
+
+@Component({
+  selector: 'shared-pages-innovation-record-wrapper',
+  templateUrl: './innovation-record-wrapper.component.html'
+})
+export class PageInnovationRecordWrapperComponent extends CoreComponent {
+  innovation: ContextInnovationType;
+
+  // Flags
+  isInnovatorType: boolean;
+  isInnovationInArchivedStatus: boolean;
+  showAllSectionsInfo: boolean;
+
+  constructor() {
+    super();
+
+    this.innovation = this.stores.context.getInnovation();
+
+    // Flags
+    this.isInnovatorType = this.stores.authentication.isInnovatorType();
+    this.isInnovationInArchivedStatus = this.innovation.status === InnovationStatusEnum.ARCHIVED;
+    // Innovators don't have access to this component, but to make sure.
+    this.showAllSectionsInfo = this.isInnovationInArchivedStatus && !this.isInnovatorType;
+  }
+}

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.html
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.html
@@ -12,12 +12,15 @@
     <ng-container *ngIf="isInnovatorType">
       <ng-container *ngIf="sections.submitted > 0; else firstTimeBanner">
         <div class="nhsuk-grid-column-full">
-          <ng-container *ngIf="isInnovationInCreatedStatus; else innovationSharedText">
+          <ng-container *ngIf="isInnovationInCreatedStatus">
             <p>You'll need to complete all 11 sections of your innovation record before you can submit your record for a needs assessment.</p>
             <p>
               If you are unable to answer a question yet, you can still mark the section as complete. This will help us match you with organisations that can support you in these
               areas.
             </p>
+          </ng-container>
+          <ng-container *ngIf="isInnovationInArchivedStatus && isLoggedUserOwner; else innovationSharedText">
+            <p>You archived this innovation on {{ innovation.statusUpdatedAt | date: ("app.date_formats.long_date" | translate) }}. All support has ended.</p>
           </ng-container>
           <ng-template #innovationSharedText>
             <p>
@@ -64,15 +67,15 @@
           *ngIf="isInnovationInCreatedStatus"
           routerLink="/innovator/innovations/{{ innovationId }}/record/support"
           [disabled]="!allSectionsSubmitted"
-          class="nhsuk-button nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-6"
+          class="nhsuk-button nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-6"
         >
           Submit record for needs assessment
         </button>
         <button
-          *ngIf="innovation.status === 'ARCHIVED'"
+          *ngIf="isInnovationInArchivedStatus && isLoggedUserOwner"
           routerLink="/innovator/innovations/{{ innovationId }}/how-to-proceed/needs-reassessment-send"
           [disabled]="!allSectionsSubmitted"
-          class="nhsuk-button nhsuk-u-margin-bottom-4"
+          class="nhsuk-button nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-6"
         >
           Submit record for needs reassessment
         </button>

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.ts
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.ts
@@ -41,7 +41,9 @@ export class PageInnovationRecordComponent extends CoreComponent implements OnIn
   isInnovatorType: boolean;
   isAccessorType: boolean;
   isAssessmentType: boolean;
+  isLoggedUserOwner: boolean;
   isInnovationInCreatedStatus: boolean;
+  isInnovationInArchivedStatus: boolean;
   showSupportingTeamsShareRequestSection: boolean;
   showInnovatorShareRequestSection: boolean;
 
@@ -68,7 +70,9 @@ export class PageInnovationRecordComponent extends CoreComponent implements OnIn
     this.isAccessorType = this.stores.authentication.isAccessorType();
     this.isAssessmentType = this.stores.authentication.isAssessmentType();
     this.isAdminType = this.stores.authentication.isAdminRole();
+    this.isLoggedUserOwner = this.innovation.loggedUser.isOwner;
     this.isInnovationInCreatedStatus = this.innovation.status === InnovationStatusEnum.CREATED;
+    this.isInnovationInArchivedStatus = this.innovation.status === InnovationStatusEnum.ARCHIVED;
     this.showSupportingTeamsShareRequestSection =
       this.stores.authentication.isAccessorType() || this.stores.authentication.isAssessmentType();
     this.showInnovatorShareRequestSection =

--- a/src/modules/shared/pages/innovation/sections/section-info-all.component.html
+++ b/src/modules/shared/pages/innovation/sections/section-info-all.component.html
@@ -31,9 +31,14 @@
         <ng-container *ngFor="let section of item.sections; let j = index; last as lastItem">
           <div [ngClass]="lastItem ? 'nhsuk-u-margin-bottom-8' : 'nhsuk-u-margin-bottom-2'">
             <h3 class="nhsuk-heading-m nhsuk-u-margin-top-7" [id]="section.id">
-              <a routerLink="{{ baseUrl }}/record/sections/{{ section.id }}/">
+              <ng-container *ngIf="isInnovationInArchivedStatus && !isInnovatorType; else innovationLink">
                 {{ i + 1 }}.{{ j + 1 }} {{ "shared.catalog.innovation.innovation_sections." + section.id | translate }}
-              </a>
+              </ng-container>
+              <ng-template #innovationLink>
+                <a routerLink="{{ baseUrl }}/record/sections/{{ section.id }}/">
+                  {{ i + 1 }}.{{ j + 1 }} {{ "shared.catalog.innovation.innovation_sections." + section.id | translate }}
+                </a>
+              </ng-template>
             </h3>
             <ng-container *ngIf="pageStatus === 'READY'">
               <ng-container *ngIf="allSectionsData[section.id] as sectionData">
@@ -50,7 +55,7 @@
                       <ng-container *ngSwitchCase="'DRAFT'">
                         <theme-svg-icon type="edit"></theme-svg-icon>
                         <span class="nhsuk-u-margin-right-2"></span>
-                        <ng-container *ngIf="isInnovatorType; else notInnovator">
+                        <ng-container *ngIf="isInnovatorType">
                           <span *ngIf="innovation.status === 'CREATED'" class="nhsuk-u-font-size-16 nhsuk-u-margin-bottom-4"
                             >This section is in draft. You need to complete the section before you can submit your record for needs assessment.</span
                           >
@@ -58,7 +63,17 @@
                             >This section is in draft and is not visible to others. Go to the section and submit updates to make it visible again.</span
                           >
                         </ng-container>
-                        <ng-template #notInnovator><span class="nhsuk-u-font-size-16 nhsuk-u-margin-bottom-4">This section is in draft.</span></ng-template>
+                        <ng-container *ngIf="isAccessorType || isAssessmentType">
+                          <span *ngIf="isInnovationInArchivedStatus; else innovationIsNotArchived" class="nhsuk-u-font-size-16 nhsuk-u-margin-bottom-4">
+                            You cannot view this section as it was in draft when the innovation was archived.
+                          </span>
+                          <ng-template #innovationIsNotArchived>
+                            <span class="nhsuk-u-font-size-16 nhsuk-u-margin-bottom-4">This section is in draft.</span>
+                          </ng-template>
+                        </ng-container>
+                        <ng-container *ngIf="isAdmin">
+                          <span class="nhsuk-u-font-size-16 nhsuk-u-margin-bottom-4">This section is in draft.</span>
+                        </ng-container>
                       </ng-container>
 
                       <ng-container *ngSwitchCase="'SUBMITTED'">

--- a/src/modules/shared/pages/innovation/sections/section-info-all.component.ts
+++ b/src/modules/shared/pages/innovation/sections/section-info-all.component.ts
@@ -51,8 +51,10 @@ export class PageInnovationAllSectionsInfoComponent extends CoreComponent implem
   isInnovatorType: boolean;
   isAccessorType: boolean;
   isAssessmentType: boolean;
+  isAdmin: boolean;
 
   isInnovationInCreatedStatus: boolean;
+  isInnovationInArchivedStatus: boolean;
   showSupportingTeamsShareRequestSection: boolean;
   showInnovatorShareRequestSection: boolean;
 
@@ -87,7 +89,9 @@ export class PageInnovationAllSectionsInfoComponent extends CoreComponent implem
     this.isInnovatorType = this.stores.authentication.isInnovatorType();
     this.isAccessorType = this.stores.authentication.isAccessorType();
     this.isAssessmentType = this.stores.authentication.isAssessmentType();
+    this.isAdmin = this.stores.authentication.isAdminRole();
     this.isInnovationInCreatedStatus = this.innovation.status === InnovationStatusEnum.CREATED;
+    this.isInnovationInArchivedStatus = this.innovation.status === InnovationStatusEnum.ARCHIVED;
     this.showSupportingTeamsShareRequestSection =
       this.stores.authentication.isAccessorType() || this.stores.authentication.isAssessmentType();
     this.showInnovatorShareRequestSection =
@@ -97,7 +101,10 @@ export class PageInnovationAllSectionsInfoComponent extends CoreComponent implem
   ngOnInit(): void {
     this.setPageStatus('LOADING');
 
-    this.setBackLink('Innovation Record', `${this.baseUrl}/record`);
+    if (this.isInnovatorType || !this.isInnovationInArchivedStatus) {
+      this.setBackLink('Innovation Record', `${this.baseUrl}/record`);
+    }
+
     this.setPageTitle('All sections questions and answers', { hint: 'Innovation record' });
 
     this.getSectionsData();

--- a/src/modules/shared/pages/innovation/sections/section-summary.component.html
+++ b/src/modules/shared/pages/innovation/sections/section-summary.component.html
@@ -21,7 +21,7 @@
 
     <ng-container *ngIf="!sectionInfo.isNotStarted">
       <ng-container *ngIf="(isAccessorType || isAssessmentType) && sectionInfo.status.id === 'DRAFT'; else showSummary">
-        <div class="nhsuk-inset-text nhsuk-u-margin-top-2 nhsuk-u-padding-top-0 nhsuk-u-padding-bottom-0">
+        <div *ngIf="innovation.status !== 'ARCHIVED'" class="nhsuk-inset-text nhsuk-u-margin-top-2 nhsuk-u-padding-top-0 nhsuk-u-padding-bottom-0">
           <span class="nhsuk-u-visually-hidden">Information:</span>
           <p>You cannot see this section because it is in draft. If you need to see this section, create a task or send a message to the innovator asking them to resubmit it.</p>
         </div>

--- a/src/modules/shared/shared.module.ts
+++ b/src/modules/shared/shared.module.ts
@@ -99,6 +99,7 @@ import { FileUploadService } from '@modules/shared/services/file-upload.service'
 import { PageInnovationAllSectionsInfoComponent } from './pages/innovation/sections/section-info-all.component';
 import { FiltersWrapperComponent } from './components/filters-wrapper/filters-wrapper.component';
 import { FiltersSelectionWrapperComponent } from './components/filters-selection-wrapper/filters-selection-wrapper.component';
+import { PageInnovationRecordWrapperComponent } from './pages/innovation/record/innovation-record-wrapper.component';
 
 @NgModule({
   imports: [
@@ -154,6 +155,7 @@ import { FiltersSelectionWrapperComponent } from './components/filters-selection
     PageInnovationThreadRecipientsComponent,
 
     PageInnovationRecordDownloadComponent,
+    PageInnovationRecordWrapperComponent,
     PageInnovationRecordComponent,
     PageInnovationSectionInfoComponent,
     PageInnovationAllSectionsInfoComponent,


### PR DESCRIPTION
Closes tasks:

- [AB#161982](https://dev.azure.com/NHSiDev/InnovatorService/_workitems/edit/161982).
- [AB#161983](https://dev.azure.com/NHSiDev/InnovatorService/_workitems/edit/161983).

- New content message on the Innovation record page for owner innovators;
- Innovation record view will be “view all” (All sections questions and answers) mode with no links on sections, with the side menu as in other pages for QA/A/NA/Admin
