### PR TITLE
Fix display of innovation status in advanced search cards for admins

### DIFF
--- a/src/modules/shared/pages/innovations/innovation-advanced-search-card.component.html
+++ b/src/modules/shared/pages/innovations/innovation-advanced-search-card.component.html
@@ -66,8 +66,8 @@
       <span class="nhsuk-u-font-weight-bold"
         >Innovation status:
         <theme-tag
-          type="{{ 'shared.catalog.innovation.grouped_status.' + innovationCardData.status + '.cssColorClass' | translate }}"
-          label="{{ 'shared.catalog.innovation.grouped_status.' + innovationCardData.status + '.name' | translate }}"
+          type="{{ 'shared.catalog.innovation.grouped_status.' + innovationCardData.groupedStatus + '.cssColorClass' | translate }}"
+          label="{{ 'shared.catalog.innovation.grouped_status.' + innovationCardData.groupedStatus + '.name' | translate }}"
         />
       </span>
       <span *ngIf="innovationCardData.updatedAt" class="font-color-secondary">

--- a/src/modules/shared/pages/innovations/innovation-advanced-search-card.component.ts
+++ b/src/modules/shared/pages/innovations/innovation-advanced-search-card.component.ts
@@ -3,11 +3,13 @@ import { CoreComponent } from '@app/base';
 import { DateISOType } from '@app/base/types';
 import { InnovationStatusEnum } from '@modules/stores/innovation';
 import { InnovationSupportStatusEnum } from '@modules/stores/innovation';
+import { InnovationGroupedStatusEnum } from '@modules/stores/innovation/innovation.enums';
 
 export type InnovationCardData = {
   id: string;
   name: string;
   status: InnovationStatusEnum;
+  groupedStatus: InnovationGroupedStatusEnum;
   updatedAt: DateISOType;
   owner: string;
   countryName?: string | null;

--- a/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
+++ b/src/modules/shared/pages/innovations/innovations-advanced-review.component.ts
@@ -203,6 +203,7 @@ export class PageInnovationsAdvancedReviewComponent extends CoreComponent implem
             id: result.id,
             name: result.name,
             status: result.status,
+            groupedStatus: result.groupedStatus,
             updatedAt: result.updatedAt,
             owner: result.owner?.companyName ?? result.owner?.name ?? 'Deleted user',
             countryName: result.countryName ?? null,


### PR DESCRIPTION
Bug 16 on 'bugs archive' document.

![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/124596230/b9132efb-3e41-45cc-8d14-18cd8cfdf65a)
