### PR TITLE
bugfix / fixes for Archive document - items 33A / 12,16

### DIFF
--- a/src/modules/feature-modules/innovator/pages/account/account-delete.component.html
+++ b/src/modules/feature-modules/innovator/pages/account/account-delete.component.html
@@ -26,16 +26,18 @@
                 <ng-container *ngIf="innovation.expirationTransferDate === null; else innovationHasPendingTransfer">
                   <p *ngIf="innovation.collaboratorsCount === 0">There are no collaborators working on this innovation.</p>
                   <p *ngIf="innovation.collaboratorsCount > 0">
-                    You have {{ innovation.collaboratorsCount }} {{ innovation.collaboratorsCount > 1 ? "collaborators" : "collaborator" }} working on this innovation.
+                    <span>You have {{ innovation.collaboratorsCount }} {{ innovation.collaboratorsCount > 1 ? "collaborators" : "collaborator" }} working on this innovation.</span>
                   </p>
                   <p>If you do not want this innovation to be archived, you can transfer its ownership.</p>
                 </ng-container>
                 <ng-template #innovationHasPendingTransfer>
                   <p>You have requested to transfer ownership of this innovation.</p>
                   <p>
-                    This request is pending. If your request is rejected or has not been accepted within
-                    {{ getDeadlineForPendingTransferInDays(innovation.expirationTransferDate!) }}
-                    {{ getDeadlineForPendingTransferInDays(innovation.expirationTransferDate!) > 1 ? "days" : "day" }}, your innovation will be archived.
+                    <span
+                      >This request is pending. If your request is rejected or has not been accepted within
+                      {{ getDeadlineForPendingTransferInDays(innovation.expirationTransferDate!) }}
+                      {{ getDeadlineForPendingTransferInDays(innovation.expirationTransferDate!) > 1 ? "days" : "day" }}, your innovation will be archived.
+                    </span>
                   </p>
                 </ng-template>
               </dd>

--- a/src/modules/feature-modules/innovator/pages/innovation/record/section-edit.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation/record/section-edit.component.ts
@@ -21,6 +21,7 @@ export class InnovationSectionEditComponent extends CoreComponent implements OnI
   errorOnSubmitStep: boolean = false;
 
   innovation: ContextInnovationType;
+  isArchived: boolean;
   sectionId: InnovationSectionEnum;
   baseUrl: string;
 
@@ -44,6 +45,8 @@ export class InnovationSectionEditComponent extends CoreComponent implements OnI
     );
     this.wizard = this.stores.innovation.getInnovationRecordSectionWizard(this.sectionId);
 
+    this.isArchived = this.innovation.status === 'ARCHIVED';
+
     this.setBackLink('Go back', this.onSubmitStep.bind(this, 'previous'));
   }
 
@@ -55,8 +58,10 @@ export class InnovationSectionEditComponent extends CoreComponent implements OnI
   ngOnInit(): void {
     const sectionIdentification = this.stores.innovation.getInnovationRecordSectionIdentification(this.sectionId);
 
+    const savedOrSubmitted = !this.isArchived ? 'submitted' : 'saved';
+
     this.sectionSubmittedText = sectionIdentification
-      ? `You have submitted section ${sectionIdentification?.group.number}.${sectionIdentification?.section.number} '${sectionIdentification?.section.title}'`
+      ? `You have ${savedOrSubmitted} section ${sectionIdentification?.group.number}.${sectionIdentification?.section.number} '${sectionIdentification?.section.title}'`
       : '';
 
     this.stores.innovation.getSectionInfo$(this.innovation.id, this.sectionId).subscribe({
@@ -176,7 +181,7 @@ export class InnovationSectionEditComponent extends CoreComponent implements OnI
                   this.innovation.status !== InnovationStatusEnum.CREATED &&
                   this.innovation.status !== InnovationStatusEnum.WAITING_NEEDS_ASSESSMENT
                 ) {
-                  this.submitButton.label = 'Submit updates';
+                  this.submitButton.label = !this.isArchived ? 'Submit updates' : 'Save updates';
                 }
               }
 

--- a/src/modules/feature-modules/innovator/pages/innovation/record/section-submitted.component.html
+++ b/src/modules/feature-modules/innovator/pages/innovation/record/section-submitted.component.html
@@ -12,7 +12,7 @@
         </p>
       </ng-container>
 
-      <p>
+      <p *ngIf="!isArchived">
         Send a message to those who are supporting you to let them know about the changes you have made.
         <a routerLink="/innovator/innovations/{{ innovation.id }}/threads" target="_blank" rel="noopener noreferrer">Go to messages (opens in a new window).</a>
       </p>

--- a/src/modules/feature-modules/innovator/pages/innovation/record/section-submitted.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation/record/section-submitted.component.ts
@@ -11,6 +11,8 @@ import { InnovationSectionEnum } from '@modules/stores/innovation';
 export class InnovationSectionSubmittedComponent extends CoreComponent implements OnInit {
   innovation: ContextInnovationType;
 
+  isArchived: boolean;
+
   section: {
     id: InnovationSectionEnum;
     openTasksCount: number;
@@ -32,9 +34,13 @@ export class InnovationSectionSubmittedComponent extends CoreComponent implement
 
     this.setPageTitle('What you can do next', { size: 'l' });
     this.setBackLink('Go back', this.sectionLink);
+
+    this.isArchived = this.innovation.status === 'ARCHIVED';
   }
 
   ngOnInit() {
+    this.isArchived && this.setPageTitle('');
+
     this.stores.innovation.getSectionInfo$(this.innovation.id, this.section.id).subscribe({
       next: sectionInfo => {
         this.section.openTasksCount = sectionInfo.tasksIds ? sectionInfo.tasksIds.length : 0;

--- a/src/modules/shared/pages/innovation/documents/document-info.component.ts
+++ b/src/modules/shared/pages/innovation/documents/document-info.component.ts
@@ -8,6 +8,7 @@ import {
   InnovationDocumentInfoOutDTO,
   InnovationDocumentsService
 } from '@modules/shared/services/innovation-documents.service';
+import { ContextInnovationType } from '@modules/stores';
 import { getAllSectionsList } from '@modules/stores/innovation/innovation-record/ir-versions.config';
 
 @Component({
@@ -15,6 +16,7 @@ import { getAllSectionsList } from '@modules/stores/innovation/innovation-record
   templateUrl: './document-info.component.html'
 })
 export class PageInnovationDocumentInfoComponent extends CoreComponent implements OnInit {
+  innovation: ContextInnovationType;
   innovationId: string;
   documentId: string;
   pageStep: 'INFO' | 'DELETE' = 'INFO';
@@ -23,7 +25,8 @@ export class PageInnovationDocumentInfoComponent extends CoreComponent implement
   documentInfo: null | (InnovationDocumentInfoOutDTO & { locationLink: null | string }) = null;
 
   // Flags
-  canDelete = false;
+  canDelete: boolean = false;
+  isArchived: boolean;
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -31,9 +34,12 @@ export class PageInnovationDocumentInfoComponent extends CoreComponent implement
   ) {
     super();
 
+    this.innovation = this.stores.context.getInnovation();
     this.innovationId = this.activatedRoute.snapshot.params.innovationId;
     this.documentId = this.activatedRoute.snapshot.params.documentId;
     this.baseUrl = `${this.stores.authentication.userUrlBasePath()}/innovations/${this.innovationId}`;
+
+    this.isArchived = this.innovation.status === 'ARCHIVED';
   }
 
   ngOnInit(): void {

--- a/src/modules/shared/pages/innovation/documents/documents-list.component.html
+++ b/src/modules/shared/pages/innovation/documents/documents-list.component.html
@@ -1,9 +1,7 @@
 <theme-content-wrapper [status]="pageStatus">
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
-      <p *ngIf="isArchived">
-        You cannot upload documents in this section as your innovation is archived. You can add documents on your innovation record.
-      </p>
+      <p *ngIf="isArchived && isInnovatorType">You cannot upload documents in this section as your innovation is archived. You can add documents on your innovation record.</p>
 
       <ng-container *ngIf="!isArchived">
         <p *ngIf="isInnovatorType">
@@ -13,7 +11,9 @@
 
         <div *ngIf="isInnovatorType" class="nhsuk-inset-text">
           <span class="nhsuk-u-visually-hidden">Information:</span>
-          <p>If you want to upload evidence of impact and benefit, go to <a routerLink="../record/sections/EVIDENCE_OF_EFFECTIVENESS">this section of your innovation record</a>.</p>
+          <p>
+            If you want to upload evidence of impact and benefit, go to <a routerLink="../record/sections/EVIDENCE_OF_EFFECTIVENESS">this section of your innovation record</a>.
+          </p>
         </div>
 
         <button *ngIf="!isAdmin" class="nhsuk-button nhsuk-u-margin-bottom-9" routerLink="new">Upload a new document</button>

--- a/src/modules/shared/pages/innovation/messages/threads-list.component.html
+++ b/src/modules/shared/pages/innovation/messages/threads-list.component.html
@@ -6,7 +6,7 @@
     <p>Please note that the innovator {{ innovation.owner.name }} is currently locked.</p>
   </div>
 
-  <ng-container *ngIf="!canCreateThread && !isAdmin">
+  <ng-container *ngIf="!canCreateThread && !isAdmin && !isArchived">
     <div *ngIf="innovation.owner; else missingOwner" class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-full">
         <p>Once you submit your innovation record, and the needs assessment starts, you can use this space to talk about your innovation with those who are supporting you.</p>

--- a/src/modules/shared/pages/innovation/sections/section-info.component.ts
+++ b/src/modules/shared/pages/innovation/sections/section-info.component.ts
@@ -39,6 +39,7 @@ export type SectionInfoType = {
 })
 export class PageInnovationSectionInfoComponent extends CoreComponent implements OnInit {
   innovation: ContextInnovationType;
+  isArchived: boolean;
   sectionId: string;
 
   sectionSubmittedText: string = '';
@@ -71,6 +72,7 @@ export class PageInnovationSectionInfoComponent extends CoreComponent implements
 
     this.sectionId = this.activatedRoute.snapshot.params.sectionId;
     this.innovation = this.stores.context.getInnovation();
+    this.isArchived = this.innovation.status === 'ARCHIVED';
 
     this.sectionsIdsList = getInnovationRecordConfig().flatMap(sectionsGroup =>
       sectionsGroup.sections.map(section => section.id)
@@ -123,8 +125,10 @@ export class PageInnovationSectionInfoComponent extends CoreComponent implements
     this.sectionId = this.activatedRoute.snapshot.params.sectionId;
 
     const sectionIdentification = this.stores.innovation.getInnovationRecordSectionIdentification(this.sectionId);
+    const savedOrSubmitted = !this.isArchived ? 'submitted' : 'saved';
+
     this.sectionSubmittedText = sectionIdentification
-      ? `You have submitted section ${sectionIdentification?.group.number}.${sectionIdentification?.section.number} '${sectionIdentification?.section.title}'`
+      ? `You have ${savedOrSubmitted} section ${sectionIdentification?.group.number}.${sectionIdentification?.section.number} '${sectionIdentification?.section.title}'`
       : '';
 
     this.setPageTitle(this.translate(sectionIdentification!.section.title), {
@@ -197,7 +201,9 @@ export class PageInnovationSectionInfoComponent extends CoreComponent implements
             this.innovation.status !== InnovationStatusEnum.CREATED &&
             this.innovation.status !== InnovationStatusEnum.WAITING_NEEDS_ASSESSMENT
           ) {
-            this.sectionSummaryData.sectionInfo.submitButton.label = 'Submit updates';
+            this.sectionSummaryData.sectionInfo.submitButton.label = !this.isArchived
+              ? 'Submit updates'
+              : 'Save updates';
           }
         } else {
           this.sectionSummaryData.sectionInfo.submitButton.show = false;


### PR DESCRIPTION
- Fixes item 33A from dev doc
- Fixes items 12 and 16 from design doc
- Fixes trailing whitespace on 'Your innovations' descriptions' text, on delete account flow first screen.