### PR TITLE
Remove 'Documents' and 'Support summary' from sidemenu

### DIFF
--- a/src/modules/feature-modules/admin/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/admin/base/sidebar-innovation-menu-outlet.component.ts
@@ -54,11 +54,12 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
         { label: 'Innovation record', url: `/admin/innovations/${innovation.id}/record` },
         { label: 'Tasks', url: `/admin/innovations/${innovation.id}/tasks` },
         { label: 'Messages', url: `/admin/innovations/${innovation.id}/threads` },
-        ...(innovation.status !== InnovationStatusEnum.CREATED
+        ...(innovation.status !== InnovationStatusEnum.CREATED &&
+        innovation.archivedStatus !== InnovationStatusEnum.CREATED
           ? [{ label: 'Documents', url: `/admin/innovations/${innovation.id}/documents` }]
           : []),
         ...(innovation.status === InnovationStatusEnum.IN_PROGRESS ||
-        innovation.status === InnovationStatusEnum.ARCHIVED
+        innovation.archivedStatus === InnovationStatusEnum.IN_PROGRESS
           ? [{ label: 'Support summary', url: `/admin/innovations/${innovation.id}/support-summary` }]
           : []),
         { label: 'Data sharing preferences', url: `/admin/innovations/${innovation.id}/support` },

--- a/src/modules/feature-modules/innovator/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/innovator/base/sidebar-innovation-menu-outlet.component.ts
@@ -49,8 +49,6 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
     if (this.sidebarItems.length === 0) {
       const innovation = this.contextStore.getInnovation();
 
-      console.log('innovation', innovation);
-
       this.sectionsSidebar = this.innovationStore.getInnovationRecordSectionsTree('innovator', innovation.id);
       this._sidebarItems = [
         { label: 'Overview', url: `/innovator/innovations/${innovation.id}/overview` },

--- a/src/modules/feature-modules/innovator/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/innovator/base/sidebar-innovation-menu-outlet.component.ts
@@ -49,17 +49,20 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
     if (this.sidebarItems.length === 0) {
       const innovation = this.contextStore.getInnovation();
 
+      console.log('innovation', innovation);
+
       this.sectionsSidebar = this.innovationStore.getInnovationRecordSectionsTree('innovator', innovation.id);
       this._sidebarItems = [
         { label: 'Overview', url: `/innovator/innovations/${innovation.id}/overview` },
         { label: 'Innovation record', url: `/innovator/innovations/${innovation.id}/record` },
         { label: 'Tasks to do', url: `/innovator/innovations/${innovation.id}/tasks` },
         { label: 'Messages', url: `/innovator/innovations/${innovation.id}/threads` },
-        ...(innovation.status !== InnovationStatusEnum.CREATED
+        ...(innovation.status !== InnovationStatusEnum.CREATED &&
+        innovation.archivedStatus !== InnovationStatusEnum.CREATED
           ? [{ label: 'Documents', url: `/innovator/innovations/${innovation.id}/documents` }]
           : []),
         ...(innovation.status === InnovationStatusEnum.IN_PROGRESS ||
-        innovation.status === InnovationStatusEnum.ARCHIVED
+        innovation.archivedStatus === InnovationStatusEnum.IN_PROGRESS
           ? [{ label: 'Support summary', url: `/innovator/innovations/${innovation.id}/support-summary` }]
           : []),
         { label: 'Data sharing preferences', url: `/innovator/innovations/${innovation.id}/support` },

--- a/src/modules/shared/pages/innovation/support/support-summary-list.component.ts
+++ b/src/modules/shared/pages/innovation/support/support-summary-list.component.ts
@@ -86,7 +86,9 @@ export class PageInnovationSupportSummaryListComponent extends CoreComponent imp
           historyList: [],
           isLoading: false,
           isOpened: false,
-          canDoProgressUpdates: this.stores.authentication.getUserContextInfo()?.organisationUnit?.id === item.id && this.innovation.status !== InnovationStatusEnum.ARCHIVED,
+          canDoProgressUpdates:
+            this.stores.authentication.getUserContextInfo()?.organisationUnit?.id === item.id &&
+            this.innovation.status !== InnovationStatusEnum.ARCHIVED,
           temporalDescription: `Support period: ${this.datePipe.transform(item.support.start, 'MMMM y')} to present`
         }));
         this.sectionsList[1].unitsList = response.BEEN_ENGAGED.map(item => ({

--- a/src/modules/shared/services/innovations.dtos.ts
+++ b/src/modules/shared/services/innovations.dtos.ts
@@ -175,6 +175,7 @@ export type InnovationInfoDTO = {
   name: string;
   description: null | string;
   status: InnovationStatusEnum;
+  archivedStatus?: InnovationStatusEnum;
   groupedStatus: InnovationGroupedStatusEnum;
   submittedAt: null | DateISOType;
   countryName: null | string;

--- a/src/modules/stores/context/context.service.ts
+++ b/src/modules/stores/context/context.service.ts
@@ -119,6 +119,7 @@ export class ContextService {
               ? InnovationStatusEnum.AWAITING_NEEDS_REASSESSMENT
               : response.status,
           statusUpdatedAt: response.statusUpdatedAt,
+          archivedStatus: response.archivedStatus,
           ...(response.owner
             ? {
                 owner: {

--- a/src/modules/stores/context/context.types.ts
+++ b/src/modules/stores/context/context.types.ts
@@ -47,6 +47,7 @@ export type ContextInnovationType = {
   name: string;
   status: InnovationStatusEnum;
   statusUpdatedAt: null | DateISOType;
+  archivedStatus?: InnovationStatusEnum;
   countryName: string | null;
   description: string | null;
   postCode: string | null;


### PR DESCRIPTION
Show 'Documents' at the side menu only when innovation is not in 'CREATED' status and was not in 'CREATED' status when the innovation was archived.

Show 'Support summary' at the side menu only when innovation is in 'IN PROGRESS' status or was in 'IN PROGRESS' status when the innovation was archived.