### PR TITLE
fix: invalidate inno context in re/assessment

### DIFF
--- a/src/modules/feature-modules/innovator/pages/innovation/record/data-sharing-edit.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation/record/data-sharing-edit.component.ts
@@ -85,6 +85,9 @@ export class InnovationDataSharingEditComponent extends CoreComponent implements
       )
       .subscribe({
         next: () => {
+          // Make sure the innovation is refetched
+          this.stores.context.clearInnovation();
+
           this.setRedirectAlertSuccess(
             'You have successfully submitted your innovation record for a needs assessment',
             { message: `The needs assessment team will contact you within 1 week.` }

--- a/src/modules/feature-modules/innovator/services/innovator.service.ts
+++ b/src/modules/feature-modules/innovator/services/innovator.service.ts
@@ -62,6 +62,8 @@ export class InnovatorService extends CoreService {
     innovationId: string,
     body: { updatedInnovationRecord: string; description: string }
   ): Observable<{ id: string }> {
+    this.stores.context.clearInnovation();
+
     const url = new UrlModel(this.API_INNOVATIONS_URL)
       .addPath('v1/:innovationId/reassessments')
       .setPathParams({ innovationId });


### PR DESCRIPTION
**Description:**
Since we have a 5-second TTL on the innovation context, when the action was done in less than that time on re/assessment, the banner and button to do the Assessment appeared. The solution was to invalidate the context in this specific case (even though these are actions that can't be done in less than 5s since they are forms that need to be filled).

**Related tickets:**
- Closes bug 42 from archive document.