### PR TITLE
fix / Fix for MFA options not displaying correctly on manage-account

### DIFF
--- a/src/modules/shared/pages/account/manage-account-info/manage-account-info.component.html
+++ b/src/modules/shared/pages/account/manage-account-info/manage-account-info.component.html
@@ -8,9 +8,7 @@
     </div>
   </div>
 
-  <ng-container *ngIf="MFAInfo">
-    <app-account-mfa-list [MFAInfo]="MFAInfo" />
-  </ng-container>
+  <app-account-mfa-list *ngIf="MFAInfo" [MFAInfo]="MFAInfo" />
 
   <div *ngIf="isInnovator" class="nhsuk-grid-row nhsuk-u-margin-bottom-5">
     <div class="nhsuk-grid-column-full">

--- a/src/modules/shared/pages/account/manage-account-info/manage-account-info.component.html
+++ b/src/modules/shared/pages/account/manage-account-info/manage-account-info.component.html
@@ -8,7 +8,9 @@
     </div>
   </div>
 
-  <app-account-mfa-list [MFAInfo]="MFAInfo" />
+  <ng-container *ngIf="MFAInfo">
+    <app-account-mfa-list [MFAInfo]="MFAInfo" />
+  </ng-container>
 
   <div *ngIf="isInnovator" class="nhsuk-grid-row nhsuk-u-margin-bottom-5">
     <div class="nhsuk-grid-column-full">

--- a/src/modules/shared/pages/account/manage-account-info/manage-account-info.component.ts
+++ b/src/modules/shared/pages/account/manage-account-info/manage-account-info.component.ts
@@ -16,7 +16,7 @@ export class PageSharedAccountManageAccountInfoComponent extends CoreComponent i
     passwordResetAt: null | DateISOType;
   };
 
-  MFAInfo: MFAInfoDTO = { type: 'none' };
+  MFAInfo: MFAInfoDTO | null = null;
 
   isInnovator: boolean = this.stores.authentication.isInnovatorType();
 


### PR DESCRIPTION
- Fix for MFA options always displaying as 'off' on the manage-account page.