### PR TITLE
Bugfix/fixes for change button wizard

### DIFF
--- a/src/modules/feature-modules/innovator/pages/innovation/record/section-edit.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation/record/section-edit.component.ts
@@ -108,7 +108,7 @@ export class InnovationSectionEditComponent extends CoreComponent implements OnI
       if (
         this.wizard.isSummaryStep() ||
         (!this.wizard.isChangingMode && this.wizard.isFirstStep()) ||
-        (this.wizard.entryPoint === 'page' && this.wizard.getCurrentStepObjId() === [...this.wizard.visitedSteps][0])
+        this.wizard.getCurrentStepObjId() === [...this.wizard.visitedSteps][0]
       ) {
         this.redirectTo(this.stores.context.getPreviousUrl() ?? this.baseUrl);
       } else {
@@ -203,7 +203,7 @@ export class InnovationSectionEditComponent extends CoreComponent implements OnI
 
               for (const [index, item] of this.wizard.getSummary().entries()) {
                 this.displayChangeButtonList.push(index);
-                if (!item.value) {
+                if (!item.value && !item.isOptional) {
                   break;
                 }
               }

--- a/src/modules/feature-modules/innovator/pages/innovation/record/section-edit.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation/record/section-edit.component.ts
@@ -91,7 +91,7 @@ export class InnovationSectionEditComponent extends CoreComponent implements OnI
   }
 
   onChangeStep(stepNumber: number): void {
-    this.wizard.gotoStep(stepNumber, true, 'summary');
+    this.wizard.gotoStep(stepNumber, true);
     this.resetAlert();
     this.setPageTitle(this.wizard.currentStepTitle(), { showPage: false });
   }

--- a/src/modules/shared/forms/engine/models/wizard-engine.models.ts
+++ b/src/modules/shared/forms/engine/models/wizard-engine.models.ts
@@ -12,6 +12,7 @@ export type WizardSummaryType = {
   evidenceId?: string;
   allowHTML?: boolean;
   isFile?: boolean;
+  isOptional?: boolean;
 };
 
 export type StepsParentalRelationsType = {
@@ -108,10 +109,8 @@ export class WizardEngineModel {
 
   previousStep(): this {
     if (this.showSummary && this.currentStepId === 'summary') {
-      this.gotoSummary();
-    }
-
-    if (typeof this.currentStepId === 'number') {
+      this.currentStepId = this.steps.length;
+    } else if (typeof this.currentStepId === 'number') {
       if (!this.isChangingMode) {
         this.currentStepId--;
       } else {

--- a/src/modules/shared/forms/engine/models/wizard-engine.models.ts
+++ b/src/modules/shared/forms/engine/models/wizard-engine.models.ts
@@ -21,7 +21,6 @@ export type StepsParentalRelationsType = {
 
 export class WizardEngineModel {
   isChangingMode: boolean = false;
-  entryPoint?: 'page' | 'summary' = 'page';
   visitedSteps: Set<string> = new Set<string>();
   steps: WizardStepType[];
   stepsChildParentRelations: StepsParentalRelationsType;
@@ -111,14 +110,8 @@ export class WizardEngineModel {
     if (this.showSummary && this.currentStepId === 'summary') {
       this.currentStepId = this.steps.length;
     } else if (typeof this.currentStepId === 'number') {
-      if (!this.isChangingMode) {
-        this.currentStepId--;
-      } else {
-        if (this.entryPoint === 'summary' && this.getCurrentStepObjId() === [...this.visitedSteps][0]) {
-          this.gotoSummary();
-          return this;
-        }
-        this.currentStepId--;
+      this.currentStepId--;
+      if (this.isChangingMode) {
         if (this.visitedSteps.has(this.getCurrentStepObjId())) {
           return this;
         } else {
@@ -134,9 +127,8 @@ export class WizardEngineModel {
     this.currentStepId = 'summary';
   }
 
-  gotoStep(step: number | 'summary', isChangeMode: boolean = false, entryPoint?: 'page' | 'summary'): this {
+  gotoStep(step: number | 'summary', isChangeMode: boolean = false): this {
     this.visitedSteps.clear();
-    this.entryPoint = entryPoint ?? 'page';
 
     this.isChangingMode = isChangeMode;
 

--- a/src/modules/shared/pages/innovation/sections/section-summary.component.html
+++ b/src/modules/shared/pages/innovation/sections/section-summary.component.html
@@ -52,7 +52,7 @@
                     <a
                       href="javascript:void(0);"
                       routerLink="/{{ baseUrl }}/record/sections/{{ sectionInfo.id }}/edit/{{ item.editStepNumber }}"
-                      [queryParams]="item.value ? { isChangeMode: true } : {}"
+                      [queryParams]="!item.value && !item.isOptional ? {} : { isChangeMode: true }"
                       *ngIf="isInnovatorType && item.editStepNumber && displayChangeButtonList.includes(i)"
                     >
                       Change <span class="nhsuk-u-visually-hidden"> {{ item.label | lowercase }} </span>

--- a/src/modules/shared/pages/innovation/sections/section-summary.component.ts
+++ b/src/modules/shared/pages/innovation/sections/section-summary.component.ts
@@ -88,7 +88,7 @@ export class InnovationSectionSummaryComponent extends CoreComponent implements 
 
     for (const [index, item] of this.summaryList.entries()) {
       this.displayChangeButtonList.push(index);
-      if (!item.value) {
+      if (!item.value && !item.isOptional) {
         break;
       }
     }

--- a/src/modules/stores/innovation/innovation-record/202304/section-1-1.config.ts
+++ b/src/modules/stores/innovation/innovation-record/202304/section-1-1.config.ts
@@ -453,7 +453,8 @@ function summaryParsing(data: StepPayloadType): WizardSummaryType[] {
     {
       label: stepsLabels.q9.label,
       value: data.areas?.map(v => areasItems.find(item => item.value === v)?.label).join('\n'),
-      editStepNumber: editStepNumber++
+      editStepNumber: editStepNumber++,
+      isOptional: true
     },
     {
       label: stepsLabels.q10.label,

--- a/src/modules/stores/innovation/innovation-record/202304/section-4-1.config.ts
+++ b/src/modules/stores/innovation/innovation-record/202304/section-4-1.config.ts
@@ -42,7 +42,7 @@ const stepsLabels = {
 
 const stepsChildParentRelations = {
   intendedUserGroupsEngaged: 'testedWithIntendedUsers',
-  userTests: 'testedWithIntendedUsers',
+  userTests: 'intendedUserGroupsEngaged',
   userTestFeedback: 'userTests'
 };
 


### PR DESCRIPTION
- Fixes stepsChildParentRelations constant for section 4-1
- Refactor 'Go back' behaviour on summary page / fixes missing page title when changing answer and going back
- Removes unnecessarily previously added entryPoint property for wizard
- Fixes broken 'Go back' on wizard's summary page, on Admin's 'Add user' wizard.
- Adds support for 'isOptional' property to WizardSummaryType, for cases where a question's answer is optional  (there's currently only 1 case, section 1.1.7), which was breaking the 'show Change button only for the first unanswered question' logic.