### PR TITLE
Bugfix/167232 na sidemenu missing support summary link after reassessment begins

### DIFF
--- a/src/modules/feature-modules/admin/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/admin/base/sidebar-innovation-menu-outlet.component.ts
@@ -58,8 +58,12 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
         innovation.archivedStatus !== InnovationStatusEnum.CREATED
           ? [{ label: 'Documents', url: `/admin/innovations/${innovation.id}/documents` }]
           : []),
-        ...(innovation.status === InnovationStatusEnum.IN_PROGRESS ||
-        innovation.archivedStatus === InnovationStatusEnum.IN_PROGRESS
+        ...((innovation.assessment?.finishedAt == null &&
+          innovation.reassessmentCount === 0 &&
+          innovation.status !== 'ARCHIVED') ||
+        (innovation.status === 'ARCHIVED' &&
+          innovation.archivedStatus !== 'IN_PROGRESS' &&
+          innovation.reassessmentCount === 0)
           ? [{ label: 'Support summary', url: `/admin/innovations/${innovation.id}/support-summary` }]
           : []),
         { label: 'Data sharing preferences', url: `/admin/innovations/${innovation.id}/support` },

--- a/src/modules/feature-modules/admin/services/users.service.ts
+++ b/src/modules/feature-modules/admin/services/users.service.ts
@@ -171,7 +171,8 @@ export class AdminUsersService extends CoreService {
    * @param idOrEmail user id or email
    */
   getUserInfo(idOrEmail: string): Observable<UserInfo> {
-    const url = new UrlModel(this.API_ADMIN_URL).addPath(`v1/users/${idOrEmail}`);
+    const encodedIdOrEmail = encodeURIComponent(idOrEmail);
+    const url = new UrlModel(this.API_ADMIN_URL).addPath(`v1/users/${encodedIdOrEmail}`);
     return this.http.get<UserInfo>(url.buildUrl()).pipe(take(1));
   }
 

--- a/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.ts
@@ -52,8 +52,6 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
     if (this.sidebarItems.length === 0) {
       const innovation = this.contextStore.getInnovation();
 
-      const shouldShowSupportSummary: boolean = false;
-
       this.sectionsSidebar = this.innovationStore.getInnovationRecordSectionsTree('assessment', innovation.id);
       this._sidebarItems = [
         { label: 'Overview', url: `/assessment/innovations/${innovation.id}/overview` },

--- a/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.ts
@@ -52,6 +52,8 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
     if (this.sidebarItems.length === 0) {
       const innovation = this.contextStore.getInnovation();
 
+      const shouldShowSupportSummary: boolean = false;
+
       this.sectionsSidebar = this.innovationStore.getInnovationRecordSectionsTree('assessment', innovation.id);
       this._sidebarItems = [
         { label: 'Overview', url: `/assessment/innovations/${innovation.id}/overview` },
@@ -61,13 +63,14 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
         ...(innovation.status !== InnovationStatusEnum.CREATED
           ? [{ label: 'Documents', url: `/assessment/innovations/${innovation.id}/documents` }]
           : []),
-        ...([
-          InnovationStatusEnum.IN_PROGRESS,
-          InnovationStatusEnum.AWAITING_NEEDS_REASSESSMENT,
-          InnovationStatusEnum.ARCHIVED
-        ].includes(innovation.status)
-          ? [{ label: 'Support summary', url: `/assessment/innovations/${innovation.id}/support-summary` }]
-          : []),
+        ...((innovation.assessment?.finishedAt == null &&
+          innovation.reassessmentCount === 0 &&
+          innovation.status !== 'ARCHIVED') ||
+        (innovation.status === 'ARCHIVED' &&
+          innovation.archivedStatus !== 'IN_PROGRESS' &&
+          innovation.reassessmentCount === 0)
+          ? []
+          : [{ label: 'Support summary', url: `/assessment/innovations/${innovation.id}/support-summary` }]),
         { label: 'Data sharing preferences', url: `/assessment/innovations/${innovation.id}/support` },
         { label: 'Activity log', url: `/assessment/innovations/${innovation.id}/activity-log` }
       ];

--- a/src/modules/shared/pages/innovation/support/support-summary-list.component.html
+++ b/src/modules/shared/pages/innovation/support/support-summary-list.component.html
@@ -5,214 +5,218 @@
         <span class="nhsuk-u-visually-hidden">Information: </span>
         <p>If you want to stop sharing your innovation with an organisation, <a routerLink="../support">update your data sharing preferences</a>.</p>
       </div>
+      <ng-container *ngIf="!isSuggestionsListEmpty; else noSupportYetMessage">
+        <ng-container *ngFor="let sectionItem of sectionsList; let sectionIndex = index; let sectionIsFirst = first">
+          <ng-container *ngIf="sectionItem.unitsList.length">
+            <h2 [ngClass]="{ 'nhsuk-u-padding-top-3': !sectionIsFirst }">{{ sectionItem.title }}</h2>
 
-      <ng-container *ngFor="let sectionItem of sectionsList; let sectionIndex = index; let sectionIsFirst = first">
-        <ng-container *ngIf="sectionItem.unitsList.length">
-          <h2 [ngClass]="{ 'nhsuk-u-padding-top-3': !sectionIsFirst }">{{ sectionItem.title }}</h2>
-
-          <dl class="nhsuk-u-margin-0">
-            <ng-container *ngFor="let unitItem of sectionItem.unitsList; let unitIndex = index">
-              <dt [ngClass]="{ 'bottom-border-separator nhsuk-u-margin-bottom-5': !unitItem.isOpened }">
-                <button
-                  id="engaging-button-{{ unitItem.id }}"
-                  (click)="onOpenCloseUnit(sectionIndex, unitIndex)"
-                  class="d-flex button-as-link nhsuk-u-font-size-22 nhsuk-u-font-weight-bold nhsuk-u-padding-0"
-                  attr.aria-expanded="{{ unitItem.isOpened ? 'true' : 'false' }}"
-                  attr.aria-controls="engaging-section-{{ unitItem.id }}"
-                >
-                  <theme-svg-icon *ngIf="!unitItem.isOpened" type="plus" />
-                  <theme-svg-icon *ngIf="unitItem.isOpened" type="minus" />
-                  <span class="nhsuk-u-margin-left-2"> {{ unitItem.sameOrganisation ? unitItem.name + " (your organisation)" : unitItem.name }}</span>
-                </button>
-                <div class="nhsuk-u-font-size-16 nhsuk-u-padding-left-5 nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-3">
-                  <span
-                    >Status:
-                    <theme-tag
-                      type="{{ 'shared.catalog.innovation.support_status.' + unitItem.support.status + '.cssColorClass' | translate }}"
-                      label="{{ 'shared.catalog.innovation.support_status.' + unitItem.support.status + '.name' | translate }}"
-                    ></theme-tag
-                  ></span>
-                  <span *ngIf="unitItem.temporalDescription" class="nhsuk-u-margin-left-4">{{ unitItem.temporalDescription }}</span>
-                </div>
-              </dt>
-
-              <dd
-                *ngIf="unitItem.isOpened"
-                id="engaging-section-{{ unitItem.id }}"
-                class="nhsuk-u-margin-left-0 nhsuk-u-margin-bottom-5"
-                attr.aria-labelledby="engaging-button-{{ unitItem.id }}"
-              >
-                <div *ngIf="unitItem.isLoading" class="nhsuk-grid-row">
-                  <div class="nhsuk-grid-column-one-half">
-                    <theme-spinner cssClass="nhsuk-u-margin-9"></theme-spinner>
+            <dl class="nhsuk-u-margin-0">
+              <ng-container *ngFor="let unitItem of sectionItem.unitsList; let unitIndex = index">
+                <dt [ngClass]="{ 'bottom-border-separator nhsuk-u-margin-bottom-5': !unitItem.isOpened }">
+                  <button
+                    id="engaging-button-{{ unitItem.id }}"
+                    (click)="onOpenCloseUnit(sectionIndex, unitIndex)"
+                    class="d-flex button-as-link nhsuk-u-font-size-22 nhsuk-u-font-weight-bold nhsuk-u-padding-0"
+                    attr.aria-expanded="{{ unitItem.isOpened ? 'true' : 'false' }}"
+                    attr.aria-controls="engaging-section-{{ unitItem.id }}"
+                  >
+                    <theme-svg-icon *ngIf="!unitItem.isOpened" type="plus" />
+                    <theme-svg-icon *ngIf="unitItem.isOpened" type="minus" />
+                    <span class="nhsuk-u-margin-left-2"> {{ unitItem.sameOrganisation ? unitItem.name + " (your organisation)" : unitItem.name }}</span>
+                  </button>
+                  <div class="nhsuk-u-font-size-16 nhsuk-u-padding-left-5 nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-3">
+                    <span
+                      >Status:
+                      <theme-tag
+                        type="{{ 'shared.catalog.innovation.support_status.' + unitItem.support.status + '.cssColorClass' | translate }}"
+                        label="{{ 'shared.catalog.innovation.support_status.' + unitItem.support.status + '.name' | translate }}"
+                      ></theme-tag
+                    ></span>
+                    <span *ngIf="unitItem.temporalDescription" class="nhsuk-u-margin-left-4">{{ unitItem.temporalDescription }}</span>
                   </div>
-                </div>
+                </dt>
 
-                <button
-                  *ngIf="!unitItem.isLoading && unitItem.canDoProgressUpdates"
-                  routerLink="progress-update-new"
-                  class="nhsuk-button button-small nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-5"
+                <dd
+                  *ngIf="unitItem.isOpened"
+                  id="engaging-section-{{ unitItem.id }}"
+                  class="nhsuk-u-margin-left-0 nhsuk-u-margin-bottom-5"
+                  attr.aria-labelledby="engaging-button-{{ unitItem.id }}"
                 >
-                  Update progress
-                </button>
+                  <div *ngIf="unitItem.isLoading" class="nhsuk-grid-row">
+                    <div class="nhsuk-grid-column-one-half">
+                      <theme-spinner cssClass="nhsuk-u-margin-9"></theme-spinner>
+                    </div>
+                  </div>
 
-                <ul *ngIf="!unitItem.isLoading" class="list-vertical-line" style="margin-left: 9px">
-                  <li *ngFor="let historyItem of unitItem.historyList; let historyIndex = index; let historyIsLast = last">
-                    <ng-container [ngSwitch]="historyItem.type">
-                      <ng-container *ngSwitchCase="'SUPPORT_UPDATE'">
-                        <p>
-                          <span class="nhsuk-u-font-weight-bold">Updated support status</span>
-                          <span class="nhsuk-hint nhsuk-u-font-size-16">
-                            {{ historyItem.createdAt | date: ("app.date_formats.long_date" | translate) }}
-                            by
-                            <span class="nhsuk-u-font-weight-bold"
-                              >{{ historyItem.createdBy.name }}{{ historyItem.createdBy.displayRole ? " (" + historyItem.createdBy.displayRole + ")" : "" }}</span
-                            >
-                          </span>
-                        </p>
-                        <theme-tag
-                          type="{{ 'shared.catalog.innovation.support_status.' + historyItem.params.supportStatus + '.cssColorClass' | translate }}"
-                          label="{{ 'shared.catalog.innovation.support_status.' + historyItem.params.supportStatus + '.name' | translate }}"
-                        ></theme-tag>
-                        <ng-container *ngIf="historyItem.params.message">
-                          <p class="nhsuk-u-font-weight-bold font-color-secondary nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-2">Message</p>
-                          <p class="nhsuk-body-s nhsuk-u-margin-bottom-2">{{ historyItem.params.message }}</p>
+                  <button
+                    *ngIf="!unitItem.isLoading && unitItem.canDoProgressUpdates"
+                    routerLink="progress-update-new"
+                    class="nhsuk-button button-small nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-5"
+                  >
+                    Update progress
+                  </button>
+
+                  <ul *ngIf="!unitItem.isLoading" class="list-vertical-line" style="margin-left: 9px">
+                    <li *ngFor="let historyItem of unitItem.historyList; let historyIndex = index; let historyIsLast = last">
+                      <ng-container [ngSwitch]="historyItem.type">
+                        <ng-container *ngSwitchCase="'SUPPORT_UPDATE'">
+                          <p>
+                            <span class="nhsuk-u-font-weight-bold">Updated support status</span>
+                            <span class="nhsuk-hint nhsuk-u-font-size-16">
+                              {{ historyItem.createdAt | date: ("app.date_formats.long_date" | translate) }}
+                              by
+                              <span class="nhsuk-u-font-weight-bold"
+                                >{{ historyItem.createdBy.name }}{{ historyItem.createdBy.displayRole ? " (" + historyItem.createdBy.displayRole + ")" : "" }}</span
+                              >
+                            </span>
+                          </p>
+                          <theme-tag
+                            type="{{ 'shared.catalog.innovation.support_status.' + historyItem.params.supportStatus + '.cssColorClass' | translate }}"
+                            label="{{ 'shared.catalog.innovation.support_status.' + historyItem.params.supportStatus + '.name' | translate }}"
+                          ></theme-tag>
+                          <ng-container *ngIf="historyItem.params.message">
+                            <p class="nhsuk-u-font-weight-bold font-color-secondary nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-2">Message</p>
+                            <p class="nhsuk-body-s nhsuk-u-margin-bottom-2">{{ historyItem.params.message }}</p>
+                          </ng-container>
                         </ng-container>
-                      </ng-container>
 
-                      <ng-container *ngSwitchCase="'SUGGESTED_ORGANISATION'">
-                        <p>
-                          <span class="nhsuk-u-font-weight-bold">Organisation suggested by {{ historyItem.params.suggestedByName || "Needs Assessment team" }}</span>
-                          <span class="nhsuk-hint nhsuk-u-font-size-16">
-                            {{ historyItem.createdAt | date: ("app.date_formats.long_date" | translate) }}
-                            by
-                            <span class="nhsuk-u-font-weight-bold"
-                              >{{ historyItem.createdBy.name }}{{ historyItem.createdBy.displayRole ? " (" + historyItem.createdBy.displayRole + ")" : "" }}</span
-                            >
-                          </span>
-                        </p>
-                        <p *ngIf="historyItem.params.message" class="nhsuk-body-s">{{ historyItem.params.message }}</p>
-                      </ng-container>
+                        <ng-container *ngSwitchCase="'SUGGESTED_ORGANISATION'">
+                          <p>
+                            <span class="nhsuk-u-font-weight-bold">Organisation suggested by {{ historyItem.params.suggestedByName || "Needs Assessment team" }}</span>
+                            <span class="nhsuk-hint nhsuk-u-font-size-16">
+                              {{ historyItem.createdAt | date: ("app.date_formats.long_date" | translate) }}
+                              by
+                              <span class="nhsuk-u-font-weight-bold"
+                                >{{ historyItem.createdBy.name }}{{ historyItem.createdBy.displayRole ? " (" + historyItem.createdBy.displayRole + ")" : "" }}</span
+                              >
+                            </span>
+                          </p>
+                          <p *ngIf="historyItem.params.message" class="nhsuk-body-s">{{ historyItem.params.message }}</p>
+                        </ng-container>
 
-                      <ng-container *ngSwitchCase="'PROGRESS_UPDATE'">
-                        <p>
-                          <span class="nhsuk-u-font-weight-bold">Progress update: </span>
-                          <span *ngIf="historyItem.params?.title" class="nhsuk-u-font-weight-bold">{{ historyItem.params.title }}</span>
-                          <span *ngIf="historyItem.params?.categories?.length === 1" class="nhsuk-u-font-weight-bold">{{ historyItem.params.categories?.[0] }}</span>
-                          <span *ngIf="historyItem.params?.category" class="nhsuk-u-font-weight-bold">{{ historyItem.params.category }}</span>
-                          <span class="nhsuk-hint nhsuk-u-font-size-16">
-                            {{ historyItem.createdAt | date: ("app.date_formats.long_date" | translate) }}
-                            by
-                            <span class="nhsuk-u-font-weight-bold"
-                              >{{ historyItem.createdBy.name }}{{ historyItem.createdBy.displayRole ? " (" + historyItem.createdBy.displayRole + ")" : "" }}</span
-                            >
-                          </span>
-                        </p>
+                        <ng-container *ngSwitchCase="'PROGRESS_UPDATE'">
+                          <p>
+                            <span class="nhsuk-u-font-weight-bold">Progress update: </span>
+                            <span *ngIf="historyItem.params?.title" class="nhsuk-u-font-weight-bold">{{ historyItem.params.title }}</span>
+                            <span *ngIf="historyItem.params?.categories?.length === 1" class="nhsuk-u-font-weight-bold">{{ historyItem.params.categories?.[0] }}</span>
+                            <span *ngIf="historyItem.params?.category" class="nhsuk-u-font-weight-bold">{{ historyItem.params.category }}</span>
+                            <span class="nhsuk-hint nhsuk-u-font-size-16">
+                              {{ historyItem.createdAt | date: ("app.date_formats.long_date" | translate) }}
+                              by
+                              <span class="nhsuk-u-font-weight-bold"
+                                >{{ historyItem.createdBy.name }}{{ historyItem.createdBy.displayRole ? " (" + historyItem.createdBy.displayRole + ")" : "" }}</span
+                              >
+                            </span>
+                          </p>
 
-                        <p *ngIf="historyItem.params?.categories?.length === 1" class="font-color-secondary">
-                          {{ historyItem.params.categories![0] | categoryDescription: unitItem.organisation.acronym }}
-                        </p>
+                          <p *ngIf="historyItem.params?.categories?.length === 1" class="font-color-secondary">
+                            {{ historyItem.params.categories![0] | categoryDescription: unitItem.organisation.acronym }}
+                          </p>
 
-                        <p *ngIf="historyItem.params?.subCategories?.length === 1">
-                          <span>{{ historyItem.params.subCategories![0] }}:</span>
-                          <span class="font-color-secondary">
-                            {{ historyItem.params.subCategories![0] | subcategoryDescription: unitItem.organisation.acronym : historyItem.params.category! }}
-                          </span>
-                        </p>
+                          <p *ngIf="historyItem.params?.subCategories?.length === 1">
+                            <span>{{ historyItem.params.subCategories![0] }}:</span>
+                            <span class="font-color-secondary">
+                              {{ historyItem.params.subCategories![0] | subcategoryDescription: unitItem.organisation.acronym : historyItem.params.category! }}
+                            </span>
+                          </p>
 
-                        <ul *ngIf="historyItem.params.categories && historyItem.params.categories.length > 1" class="nhsuk-list nhsuk-list--bullet">
-                          <li *ngFor="let categories of historyItem.params.categories">
-                            {{ categories }}
-                          </li>
-                        </ul>
+                          <ul *ngIf="historyItem.params.categories && historyItem.params.categories.length > 1" class="nhsuk-list nhsuk-list--bullet">
+                            <li *ngFor="let categories of historyItem.params.categories">
+                              {{ categories }}
+                            </li>
+                          </ul>
 
-                        <ul *ngIf="historyItem.params.subCategories && historyItem.params.subCategories.length > 1" class="nhsuk-list nhsuk-list--bullet">
-                          <li *ngFor="let subcategories of historyItem.params.subCategories">
-                            {{ subcategories }}
-                          </li>
-                        </ul>
+                          <ul *ngIf="historyItem.params.subCategories && historyItem.params.subCategories.length > 1" class="nhsuk-list nhsuk-list--bullet">
+                            <li *ngFor="let subcategories of historyItem.params.subCategories">
+                              {{ subcategories }}
+                            </li>
+                          </ul>
 
-                        <p
-                          *ngIf="
-                            (historyItem.params.categories && historyItem.params.categories.length > 1) ||
-                            (historyItem.params.subCategories && historyItem.params.subCategories.length > 1)
-                          "
-                        >
-                          <a routerLink="../../../organisation/{{ unitItem.organisation.id }}/progress-categories" target="_blank" rel="noopener noreferrer"
-                            >Find out what these progress categories mean (opens in new window).</a
+                          <p
+                            *ngIf="
+                              (historyItem.params.categories && historyItem.params.categories.length > 1) ||
+                              (historyItem.params.subCategories && historyItem.params.subCategories.length > 1)
+                            "
                           >
-                        </p>
-                        <p>
-                          <span class="d-block nhsuk-u-font-weight-bold font-color-secondary">Comment</span>
-                          <span>{{ historyItem.params.message }}</span>
-                        </p>
-                        <p *ngIf="unitItem.canDoProgressUpdates || historyItem.params.file">
-                          <span class="d-block nhsuk-u-font-weight-bold font-color-secondary">Document</span>
-                          <span *ngIf="!historyItem.params.file">
-                            No document added.
-                            <a *ngIf="unitItem.canDoProgressUpdates" routerLink="../documents/new" [queryParams]="{ progressUpdateId: historyItem.id }">Add a document.</a>
-                          </span>
-                          <a *ngIf="historyItem.params.file" routerLink="../documents/{{ historyItem.params.file.id }}">{{ historyItem.params.file.name }}</a>
-                        </p>
-                        <a
-                          *ngIf="unitItem.canDoProgressUpdates"
-                          routerLink="{{ historyItem.id }}/progress-update-delete-confirmation"
-                          class="nhsuk-button button-small nhsuk-button--secondary nhsuk-u-margin-bottom-2"
-                          >Delete this entry</a
-                        >
-                      </ng-container>
-
-                      <ng-container *ngSwitchCase="'INNOVATION_ARCHIVED'">
-                        <p>
-                          <span class="nhsuk-u-font-weight-bold">Innovation archived</span>
-                          <span class="nhsuk-hint nhsuk-u-font-size-16">
-                            {{ historyItem.createdAt | date: ("app.date_formats.long_date" | translate) }}
-                            by
-                            <span class="nhsuk-u-font-weight-bold"
-                              >{{ historyItem.createdBy.name }}{{ historyItem.createdBy.displayRole ? " (" + historyItem.createdBy.displayRole + ")" : "" }}</span
+                            <a routerLink="../../../organisation/{{ unitItem.organisation.id }}/progress-categories" target="_blank" rel="noopener noreferrer"
+                              >Find out what these progress categories mean (opens in new window).</a
                             >
-                          </span>
-                        </p>
-                        <theme-tag
-                          type="{{ 'shared.catalog.innovation.support_status.' + historyItem.params.supportStatus + '.cssColorClass' | translate }}"
-                          label="{{ 'shared.catalog.innovation.support_status.' + historyItem.params.supportStatus + '.name' | translate }}"
-                        ></theme-tag>
-                        <ng-container *ngIf="historyItem.params.message">
-                          <p class="nhsuk-u-font-weight-bold font-color-secondary nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-2">Message</p>
-                          <p class="nhsuk-body-s nhsuk-u-margin-bottom-2">{{ historyItem.params.message }}</p>
+                          </p>
+                          <p>
+                            <span class="d-block nhsuk-u-font-weight-bold font-color-secondary">Comment</span>
+                            <span>{{ historyItem.params.message }}</span>
+                          </p>
+                          <p *ngIf="unitItem.canDoProgressUpdates || historyItem.params.file">
+                            <span class="d-block nhsuk-u-font-weight-bold font-color-secondary">Document</span>
+                            <span *ngIf="!historyItem.params.file">
+                              No document added.
+                              <a *ngIf="unitItem.canDoProgressUpdates" routerLink="../documents/new" [queryParams]="{ progressUpdateId: historyItem.id }">Add a document.</a>
+                            </span>
+                            <a *ngIf="historyItem.params.file" routerLink="../documents/{{ historyItem.params.file.id }}">{{ historyItem.params.file.name }}</a>
+                          </p>
+                          <a
+                            *ngIf="unitItem.canDoProgressUpdates"
+                            routerLink="{{ historyItem.id }}/progress-update-delete-confirmation"
+                            class="nhsuk-button button-small nhsuk-button--secondary nhsuk-u-margin-bottom-2"
+                            >Delete this entry</a
+                          >
+                        </ng-container>
+
+                        <ng-container *ngSwitchCase="'INNOVATION_ARCHIVED'">
+                          <p>
+                            <span class="nhsuk-u-font-weight-bold">Innovation archived</span>
+                            <span class="nhsuk-hint nhsuk-u-font-size-16">
+                              {{ historyItem.createdAt | date: ("app.date_formats.long_date" | translate) }}
+                              by
+                              <span class="nhsuk-u-font-weight-bold"
+                                >{{ historyItem.createdBy.name }}{{ historyItem.createdBy.displayRole ? " (" + historyItem.createdBy.displayRole + ")" : "" }}</span
+                              >
+                            </span>
+                          </p>
+                          <theme-tag
+                            type="{{ 'shared.catalog.innovation.support_status.' + historyItem.params.supportStatus + '.cssColorClass' | translate }}"
+                            label="{{ 'shared.catalog.innovation.support_status.' + historyItem.params.supportStatus + '.name' | translate }}"
+                          ></theme-tag>
+                          <ng-container *ngIf="historyItem.params.message">
+                            <p class="nhsuk-u-font-weight-bold font-color-secondary nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-2">Message</p>
+                            <p class="nhsuk-body-s nhsuk-u-margin-bottom-2">{{ historyItem.params.message }}</p>
+                          </ng-container>
+                        </ng-container>
+
+                        <ng-container *ngSwitchCase="'STOP_SHARE'">
+                          <p>
+                            <span class="nhsuk-u-font-weight-bold">Innovator stopped sharing</span>
+                            <span class="nhsuk-hint nhsuk-u-font-size-16">
+                              {{ historyItem.createdAt | date: ("app.date_formats.long_date" | translate) }}
+                              by
+                              <span class="nhsuk-u-font-weight-bold"
+                                >{{ historyItem.createdBy.name }}{{ historyItem.createdBy.displayRole ? " (" + historyItem.createdBy.displayRole + ")" : "" }}</span
+                              >
+                            </span>
+                          </p>
+                          <theme-tag
+                            type="{{ 'shared.catalog.innovation.support_status.' + historyItem.params.supportStatus + '.cssColorClass' | translate }}"
+                            label="{{ 'shared.catalog.innovation.support_status.' + historyItem.params.supportStatus + '.name' | translate }}"
+                          ></theme-tag>
                         </ng-container>
                       </ng-container>
 
-                      <ng-container *ngSwitchCase="'STOP_SHARE'">
-                        <p>
-                          <span class="nhsuk-u-font-weight-bold">Innovator stopped sharing</span>
-                          <span class="nhsuk-hint nhsuk-u-font-size-16">
-                            {{ historyItem.createdAt | date: ("app.date_formats.long_date" | translate) }}
-                            by
-                            <span class="nhsuk-u-font-weight-bold"
-                              >{{ historyItem.createdBy.name }}{{ historyItem.createdBy.displayRole ? " (" + historyItem.createdBy.displayRole + ")" : "" }}</span
-                            >
-                          </span>
-                        </p>
-                        <theme-tag
-                          type="{{ 'shared.catalog.innovation.support_status.' + historyItem.params.supportStatus + '.cssColorClass' | translate }}"
-                          label="{{ 'shared.catalog.innovation.support_status.' + historyItem.params.supportStatus + '.name' | translate }}"
-                        ></theme-tag>
-                      </ng-container>
-                    </ng-container>
+                      <hr *ngIf="!historyIsLast" class="nhsuk-section-break nhsuk-section-break--visible nhsuk-u-margin-top-3" />
+                    </li>
+                  </ul>
 
-                    <hr *ngIf="!historyIsLast" class="nhsuk-section-break nhsuk-section-break--visible nhsuk-u-margin-top-3" />
-                  </li>
-                </ul>
+                  <a href="javascript:void()" (click)="goToFragment('engaging-button-' + unitItem.id)" class="nhsuk-u-font-size-14">Back to top</a>
 
-                <a href="javascript:void()" (click)="goToFragment('engaging-button-' + unitItem.id)" class="nhsuk-u-font-size-14">Back to top</a>
-
-                <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-u-margin-top-3" />
-              </dd>
-            </ng-container>
-          </dl>
+                  <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-u-margin-top-3" />
+                </dd>
+              </ng-container>
+            </dl>
+          </ng-container>
         </ng-container>
       </ng-container>
+      <ng-template #noSupportYetMessage>
+        <p>This support summary is blank as the innovation has not received any support yet.</p>
+      </ng-template>
 
       <ng-container *ngIf="innovation.assessment && innovation.assessment.finishedAt !== null">
         <h2 class="nhsuk-u-padding-top-3">Needs assessment</h2>

--- a/src/modules/shared/pages/innovation/support/support-summary-list.component.ts
+++ b/src/modules/shared/pages/innovation/support/support-summary-list.component.ts
@@ -45,6 +45,8 @@ export class PageInnovationSupportSummaryListComponent extends CoreComponent imp
   isInnovatorType: boolean;
   isAccessorType: boolean;
 
+  isSuggestionsListEmpty: boolean = true;
+
   sectionsList: sectionsListType[] = [
     { id: 'ENGAGING', title: 'Organisations currently supporting this innovation', unitsList: [] },
     { id: 'BEEN_ENGAGED', title: 'Organisations that have supported this innovation in the past', unitsList: [] },
@@ -112,6 +114,8 @@ export class PageInnovationSupportSummaryListComponent extends CoreComponent imp
             ? `Date: ${this.datePipe.transform(item.support.start, 'MMMM y')}`
             : ''
         }));
+
+        this.isSuggestionsListEmpty = !this.sectionsList.some(s => s.unitsList.length > 0);
 
         const queryUnitId = this.activatedRoute.snapshot.queryParams.unitId;
 


### PR DESCRIPTION
- Changes rules to hide/show `Support summary` button for NA and Admin

Closes bug [#AB167232](https://nhsidev.visualstudio.com/InnovatorService/_workitems/edit/167232)
