### PR TITLE
Bugfix master/167232 NA sidemenu missing supportsummary link after reassessment begins

### DIFF
--- a/src/modules/feature-modules/admin/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/admin/base/sidebar-innovation-menu-outlet.component.ts
@@ -58,10 +58,14 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
         innovation.archivedStatus !== InnovationStatusEnum.CREATED
           ? [{ label: 'Documents', url: `/admin/innovations/${innovation.id}/documents` }]
           : []),
-        ...(innovation.status === InnovationStatusEnum.IN_PROGRESS ||
-        innovation.archivedStatus === InnovationStatusEnum.IN_PROGRESS
-          ? [{ label: 'Support summary', url: `/admin/innovations/${innovation.id}/support-summary` }]
-          : []),
+        ...((innovation.assessment?.finishedAt == null &&
+          innovation.reassessmentCount === 0 &&
+          innovation.status !== 'ARCHIVED') ||
+        (innovation.status === 'ARCHIVED' &&
+          innovation.archivedStatus !== 'IN_PROGRESS' &&
+          innovation.reassessmentCount === 0)
+          ? []
+          : [{ label: 'Support summary', url: `/assessment/innovations/${innovation.id}/support-summary` }]),
         { label: 'Data sharing preferences', url: `/admin/innovations/${innovation.id}/support` },
         { label: 'Activity log', url: `/admin/innovations/${innovation.id}/activity-log` }
       ];

--- a/src/modules/feature-modules/admin/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/admin/base/sidebar-innovation-menu-outlet.component.ts
@@ -58,12 +58,7 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
         innovation.archivedStatus !== InnovationStatusEnum.CREATED
           ? [{ label: 'Documents', url: `/admin/innovations/${innovation.id}/documents` }]
           : []),
-        ...((innovation.assessment?.finishedAt == null &&
-          innovation.reassessmentCount === 0 &&
-          innovation.status !== 'ARCHIVED') ||
-        (innovation.status === 'ARCHIVED' &&
-          innovation.archivedStatus !== 'IN_PROGRESS' &&
-          innovation.reassessmentCount === 0)
+        ...(innovation.assessment?.finishedAt == null && innovation.reassessmentCount === 0
           ? []
           : [{ label: 'Support summary', url: `/assessment/innovations/${innovation.id}/support-summary` }]),
         { label: 'Data sharing preferences', url: `/admin/innovations/${innovation.id}/support` },

--- a/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.ts
@@ -61,12 +61,7 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
         ...(innovation.status !== InnovationStatusEnum.CREATED
           ? [{ label: 'Documents', url: `/assessment/innovations/${innovation.id}/documents` }]
           : []),
-        ...((innovation.assessment?.finishedAt == null &&
-          innovation.reassessmentCount === 0 &&
-          innovation.status !== 'ARCHIVED') ||
-        (innovation.status === 'ARCHIVED' &&
-          innovation.archivedStatus !== 'IN_PROGRESS' &&
-          innovation.reassessmentCount === 0)
+        ...(innovation.assessment?.finishedAt == null && innovation.reassessmentCount === 0
           ? []
           : [{ label: 'Support summary', url: `/assessment/innovations/${innovation.id}/support-summary` }]),
         { label: 'Data sharing preferences', url: `/assessment/innovations/${innovation.id}/support` },

--- a/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.ts
@@ -61,13 +61,14 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
         ...(innovation.status !== InnovationStatusEnum.CREATED
           ? [{ label: 'Documents', url: `/assessment/innovations/${innovation.id}/documents` }]
           : []),
-        ...([
-          InnovationStatusEnum.IN_PROGRESS,
-          InnovationStatusEnum.AWAITING_NEEDS_REASSESSMENT,
-          InnovationStatusEnum.ARCHIVED
-        ].includes(innovation.status)
-          ? [{ label: 'Support summary', url: `/assessment/innovations/${innovation.id}/support-summary` }]
-          : []),
+        ...((innovation.assessment?.finishedAt == null &&
+          innovation.reassessmentCount === 0 &&
+          innovation.status !== 'ARCHIVED') ||
+        (innovation.status === 'ARCHIVED' &&
+          innovation.archivedStatus !== 'IN_PROGRESS' &&
+          innovation.reassessmentCount === 0)
+          ? []
+          : [{ label: 'Support summary', url: `/assessment/innovations/${innovation.id}/support-summary` }]),
         { label: 'Data sharing preferences', url: `/assessment/innovations/${innovation.id}/support` },
         { label: 'Activity log', url: `/assessment/innovations/${innovation.id}/activity-log` }
       ];


### PR DESCRIPTION
- Changes rules to hide/show Support summary button for NA and Admin

Closes bug [#AB167232](https://nhsidev.visualstudio.com/InnovatorService/_workitems/edit/167232)