### PR TITLE
bugfix / 167611 - Remove encoding from 'getUserInfo'

### DIFF
--- a/src/modules/feature-modules/admin/services/users.service.ts
+++ b/src/modules/feature-modules/admin/services/users.service.ts
@@ -171,8 +171,7 @@ export class AdminUsersService extends CoreService {
    * @param idOrEmail user id or email
    */
   getUserInfo(idOrEmail: string): Observable<UserInfo> {
-    const encodedIdOrEmail = encodeURIComponent(idOrEmail);
-    const url = new UrlModel(this.API_ADMIN_URL).addPath(`v1/users/${encodedIdOrEmail}`);
+    const url = new UrlModel(this.API_ADMIN_URL).addPath(`v1/users/${idOrEmail}`);
     return this.http.get<UserInfo>(url.buildUrl()).pipe(take(1));
   }
 


### PR DESCRIPTION
- Removes encoding from `AdminUsersService.getUserInfo`, in order to avoid double encoding on the backend

Closes bug [#AB167611](https://nhsidev.visualstudio.com/InnovatorService/_workitems/edit/167611)