### PR TITLE
task: add suggestion fields to unassigned list

### DIFF
--- a/src/modules/feature-modules/accessor/pages/innovations/innovations-review.component.html
+++ b/src/modules/feature-modules/accessor/pages/innovations/innovations-review.component.html
@@ -102,6 +102,16 @@
                 {{ item.support?.updatedAt | date: ("app.date_formats.long_date" | translate) }}
               </td>
 
+              <td *ngIf="innovationsList.getColumnLabel('suggestion.suggestedOn')" class="nhsuk-table__cell text-nowrap-only-desktop">
+                <span class="nhsuk-table-responsive__heading">{{ innovationsList.getColumnLabel("suggestion.suggestedOn") }} </span>
+                {{ item.suggestion?.suggestedOn | date: ("app.date_formats.long_date" | translate) }}
+              </td>
+
+              <td *ngIf="innovationsList.getColumnLabel('suggestion.suggestedBy')" class="nhsuk-table__cell">
+                <span class="nhsuk-table-responsive__heading">{{ innovationsList.getColumnLabel("suggestion.suggestedBy") }} </span>
+                {{ item.suggestion?.suggestedBy ?? [] | joinArray }}
+              </td>
+
               <td *ngIf="innovationsList.getColumnLabel('mainCategory')" class="nhsuk-table__cell">
                 <span class="nhsuk-table-responsive__heading">{{ innovationsList.getColumnLabel("mainCategory") }}</span>
                 {{ item.mainCategory }}

--- a/src/modules/feature-modules/accessor/pages/innovations/innovations-review.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovations/innovations-review.component.ts
@@ -73,6 +73,10 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
           label: string | null;
         };
       } | null;
+      suggestion: {
+        suggestedBy: string[];
+        suggestedOn: DateISOType;
+      } | null;
     },
     InnovationsListFiltersType
   >;
@@ -184,7 +188,9 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
             'assessment.id',
             'support.status',
             'statistics.notifications',
-            'engagingOrganisations'
+            'engagingOrganisations',
+            'suggestion.suggestedOn',
+            'suggestion.suggestedBy'
           ],
           notifications: null
         },
@@ -346,6 +352,10 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
                           ? 'Closed'
                           : null
                 }
+              },
+              suggestion: item.suggestion && {
+                suggestedBy: item.suggestion.suggestedBy,
+                suggestedOn: item.suggestion.suggestedOn
               }
             };
           }),
@@ -374,9 +384,9 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
           })
           .setVisibleColumns({
             name: { label: 'Innovation', orderable: true },
-            submittedAt: { label: 'Submitted', orderable: true },
+            'suggestion.suggestedOn': { label: 'Suggested on', orderable: true },
+            'suggestion.suggestedBy': { label: 'Suggested by', orderable: false },
             mainCategory: { label: 'Main category', orderable: true },
-            countryName: { label: 'Location', orderable: true },
             engagingOrganisations: { label: 'Engaging organisations', align: 'right', orderable: false }
           })
           .setOrderBy('submittedAt', 'descending');
@@ -478,6 +488,10 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
       this.form.reset();
     } else if (queryParams.assignedToMe) {
       this.form.get('assignedToMe')?.setValue(true);
+    }
+
+    if (this.currentTab.key === InnovationSupportStatusEnum.UNASSIGNED) {
+      this.form.get('suggestedOnly')?.setValue(true);
     }
 
     this.prepareInnovationsList(this.currentTab.key);

--- a/src/modules/shared/pipes/join-array.pipe.spec.ts
+++ b/src/modules/shared/pipes/join-array.pipe.spec.ts
@@ -1,0 +1,16 @@
+import { JoinArrayPipe } from './join-array.pipe';
+
+describe('shared / pipes / JoinArrayPipe', () => {
+  const pipe = new JoinArrayPipe();
+  const input = ['item 1', 'item 2', 'item 3'];
+
+  it('should return a string separated by ", " by default', () => {
+    const result = pipe.transform(input);
+    expect(result).toBe('item 1, item 2, item 3');
+  });
+
+  it('should return a string separated by " | " if passed', () => {
+    const result = pipe.transform(input, ' | ');
+    expect(result).toBe('item 1 | item 2 | item 3');
+  });
+});

--- a/src/modules/shared/pipes/join-array.pipe.ts
+++ b/src/modules/shared/pipes/join-array.pipe.ts
@@ -1,0 +1,8 @@
+import { Pipe, PipeTransform } from "@angular/core";
+
+@Pipe({ name: 'joinArray' })
+export class JoinArrayPipe implements PipeTransform {
+    transform(value: unknown[], separator: string = ', ') {
+      return value.join(separator);
+    }
+}

--- a/src/modules/shared/services/innovations.dtos.ts
+++ b/src/modules/shared/services/innovations.dtos.ts
@@ -75,6 +75,8 @@ export type InnovationListSelectType =
   | 'engagingOrganisations'
   | 'engagingUnits'
   | 'suggestedOrganisations'
+  | 'suggestion.suggestedBy'
+  | 'suggestion.suggestedOn'
   | 'support.status'
   | 'support.updatedAt'
   | 'support.updatedBy'
@@ -121,6 +123,7 @@ export type InnovationListFullDTO = {
     updatedBy: string | null;
     closedReason: InnovationStatusEnum.ARCHIVED | 'STOPPED_SHARED' | InnovationSupportStatusEnum.CLOSED | null;
   } | null;
+  suggestion: { suggestedBy: string[]; suggestedOn: DateISOType } | null;
   assessment: { id: string; assignedTo: string | null; updatedAt: DateISOType; isExempt: boolean } | null;
   statistics: { notifications: number; tasks: number; messages: number };
 };

--- a/src/modules/shared/shared.module.ts
+++ b/src/modules/shared/shared.module.ts
@@ -76,6 +76,9 @@ import { WizardSummaryWithConfirmStepComponent } from './wizards/steps/summary-w
 // Pipes.
 import { BytesPrettyPrintPipe } from './pipes/bytes-pretty-print.pipe';
 import { PluralTranslatePipe } from './pipes/plural-translate.pipe';
+import { ProgressCategoriesCategoryDescriptionPipe } from './pipes/progress-categories/subcategory-description.pipe';
+import { ProgressCategoriesSubcategoryDescriptionPipe } from './pipes/progress-categories/category-description.pipe';
+import { JoinArrayPipe } from './pipes/join-array.pipe';
 
 // Components
 import { OrganisationSuggestionsCardComponent } from './pages/innovation/data-sharing-and-support/components/organisation-suggestion-card.component';
@@ -112,8 +115,6 @@ import { PageSharedAccountManageAccountInfoComponent } from './pages/account/man
 import { PageProgressCategoriesWrapperComponent } from './pages/progress-categories/progress-categories-wrapper.component';
 import { PageProgressCategoriesOneLevelMilestoneComponent } from './pages/progress-categories/progress-categories-one-level-milestone.component';
 import { PageProgressCategoriesTwoLevelMilestoneComponent } from './pages/progress-categories/progress-categories-two-level-milestone.component';
-import { ProgressCategoriesCategoryDescriptionPipe } from './pipes/progress-categories/subcategory-description.pipe';
-import { ProgressCategoriesSubcategoryDescriptionPipe } from './pipes/progress-categories/category-description.pipe';
 
 @NgModule({
   imports: [
@@ -208,6 +209,7 @@ import { ProgressCategoriesSubcategoryDescriptionPipe } from './pipes/progress-c
     // Pipes.
     BytesPrettyPrintPipe,
     PluralTranslatePipe,
+    JoinArrayPipe,
     ProgressCategoriesCategoryDescriptionPipe,
     ProgressCategoriesSubcategoryDescriptionPipe,
 
@@ -245,7 +247,8 @@ import { ProgressCategoriesSubcategoryDescriptionPipe } from './pipes/progress-c
 
     // Pipes.
     BytesPrettyPrintPipe,
-    PluralTranslatePipe
+    PluralTranslatePipe,
+    JoinArrayPipe
   ]
 })
 export class SharedModule {}


### PR DESCRIPTION
**Description:**
- Add `suggestedBy` and `suggestedOn` added to unassigned table.
- Added pipe to transform an array into a string.
- Only suggested is always set by default.

**Related tickets:**
- Closes AB#167234.
- US: AB#162383.

**Screenshots:**
![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/115171210/665c9658-614d-4c0f-9814-85200942e954)
![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/115171210/71b51834-8c77-412b-be7b-8b63cf160ab3)
