### PR TITLE
bugifx / fixes on Suggestions cards 

### DIFF
--- a/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.html
+++ b/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.html
@@ -6,7 +6,7 @@
     <p>Please note that the innovator {{ innovation.owner.name }} is currently locked.</p>
   </div>
 
-  <app-suggestions-cards [innovationId]="innovation.id" [suggestions]="qaSuggestions" />
+  <app-suggestions-cards *ngIf="isQualifyingAccessorRole" [innovationId]="innovation.id" [innovationStatus]="innovation.status" [suggestions]="qaSuggestions" />
 
   <p class="nhsuk-heading-s nhsuk-u-margin-bottom-4">{{ innovationSupport.organisationUnit }}</p>
   <div class="nhsuk-u-margin-bottom-8">

--- a/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.ts
@@ -14,7 +14,7 @@ import { InnovationsService } from '@modules/shared/services/innovations.service
 import { InnovationStatisticsEnum, UserStatisticsTypeEnum } from '@modules/shared/services/statistics.enum';
 import { StatisticsService } from '@modules/shared/services/statistics.service';
 import { InnovationService } from '@modules/stores';
-import { InnovationQASuggestionType } from '@modules/stores/innovation/innovation.models';
+import { InnovationUnitSuggestionsType } from '@modules/stores/innovation/innovation.models';
 
 @Component({
   selector: 'app-accessor-pages-innovation-overview',
@@ -25,7 +25,7 @@ export class InnovationOverviewComponent extends CoreComponent implements OnInit
   innovation: ContextInnovationType;
   innovationSupportStatus = this.stores.innovation.INNOVATION_SUPPORT_STATUS;
 
-  qaSuggestions: InnovationQASuggestionType = [];
+  qaSuggestions: InnovationUnitSuggestionsType = [];
 
   isQualifyingAccessorRole = false;
   isAccessorRole = false;

--- a/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.ts
@@ -75,9 +75,11 @@ export class InnovationOverviewComponent extends CoreComponent implements OnInit
       ...(this.innovation.support?.id && {
         support: this.innovationsService.getInnovationSupportInfo(this.innovationId, this.innovation.support.id)
       }),
-      unitsSuggestions: this.innovationService.getInnovationQASuggestions(this.innovation.id)
+      ...(this.isQualifyingAccessorRole && {
+        unitsSuggestions: this.innovationService.getInnovationQASuggestions(this.innovation.id)
+      })
     }).subscribe(({ support, statistics, collaborators, unitsSuggestions }) => {
-      this.qaSuggestions = unitsSuggestions;
+      this.qaSuggestions = unitsSuggestions ?? [];
 
       const innovationInfo = this.innovation;
 

--- a/src/modules/stores/innovation/innovation.models.ts
+++ b/src/modules/stores/innovation/innovation.models.ts
@@ -138,7 +138,7 @@ export type OrganisationSuggestionModel = {
   accessors: AccessorSuggestionModel[];
 };
 
-export type InnovationQASuggestionType = {
+export type InnovationUnitSuggestionsType = {
   suggestionId: string;
   suggestorUnit: string;
   thread: {

--- a/src/modules/stores/innovation/innovation.service.ts
+++ b/src/modules/stores/innovation/innovation.service.ts
@@ -12,7 +12,7 @@ import {
   GetInnovationEvidenceDTO,
   INNOVATION_STATUS,
   InnovationAllSectionsInfoDTO,
-  InnovationQASuggestionType as InnovationUnitsSuggestionType,
+  InnovationUnitSuggestionsType as InnovationUnitsSuggestionType,
   InnovationSectionInfoDTO,
   InnovationSectionsListDTO,
   OrganisationSuggestionModel

--- a/src/modules/stores/innovation/innovation.service.ts
+++ b/src/modules/stores/innovation/innovation.service.ts
@@ -12,7 +12,7 @@ import {
   GetInnovationEvidenceDTO,
   INNOVATION_STATUS,
   InnovationAllSectionsInfoDTO,
-  InnovationUnitSuggestionsType as InnovationUnitsSuggestionType,
+  InnovationUnitSuggestionsType,
   InnovationSectionInfoDTO,
   InnovationSectionsListDTO,
   OrganisationSuggestionModel
@@ -148,11 +148,11 @@ export class InnovationService {
     );
   }
 
-  getInnovationQASuggestions(innovationId: string): Observable<InnovationUnitsSuggestionType> {
+  getInnovationQASuggestions(innovationId: string): Observable<InnovationUnitSuggestionsType> {
     const url = new UrlModel(this.API_INNOVATIONS_URL)
       .addPath('v1/:innovationId/units-suggestions')
       .setPathParams({ innovationId });
-    return this.http.get<InnovationUnitsSuggestionType>(url.buildUrl()).pipe(
+    return this.http.get<InnovationUnitSuggestionsType>(url.buildUrl()).pipe(
       take(1),
       map(response => response)
     );

--- a/src/modules/theme/components/suggestions-cards/suggestions-cards-component.ts
+++ b/src/modules/theme/components/suggestions-cards/suggestions-cards-component.ts
@@ -1,16 +1,20 @@
 import { Component, Input } from '@angular/core';
 import { AuthenticationStore } from '@modules/stores';
-import { InnovationQASuggestionType } from '@modules/stores/innovation/innovation.models';
+import { InnovationStatusEnum } from '@modules/stores/innovation';
+import { InnovationQASuggestionType as InnovationUnitSuggestionsType } from '@modules/stores/innovation/innovation.models';
 
 @Component({
   selector: 'app-suggestions-cards',
   templateUrl: './suggestions-cards.component.html'
 })
 export class SuggestionsCardsComponent {
+  @Input({ required: true }) innovationId!: string;
+  @Input({ required: true }) innovationStatus!: InnovationStatusEnum;
+  @Input({ required: true }) suggestions!: InnovationUnitSuggestionsType;
+
   baseUrl: string;
+
   constructor(authenticationStore: AuthenticationStore) {
     this.baseUrl = `${authenticationStore.userUrlBasePath()}`;
   }
-  @Input({ required: true }) innovationId: string = '';
-  @Input({ required: true }) suggestions: InnovationQASuggestionType = [];
 }

--- a/src/modules/theme/components/suggestions-cards/suggestions-cards-component.ts
+++ b/src/modules/theme/components/suggestions-cards/suggestions-cards-component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { AuthenticationStore } from '@modules/stores';
 import { InnovationStatusEnum } from '@modules/stores/innovation';
-import { InnovationQASuggestionType as InnovationUnitSuggestionsType } from '@modules/stores/innovation/innovation.models';
+import { InnovationUnitSuggestionsType } from '@modules/stores/innovation/innovation.models';
 
 @Component({
   selector: 'app-suggestions-cards',

--- a/src/modules/theme/components/suggestions-cards/suggestions-cards.component.html
+++ b/src/modules/theme/components/suggestions-cards/suggestions-cards.component.html
@@ -8,13 +8,15 @@
         {{ suggestion.thread.message }}
       </p>
     </li>
-    <li>
-      <p><a routerLink="/{{ baseUrl }}/innovations/{{ innovationId }}/threads/{{ suggestion.thread.id }}">Send a reply in messages</a></p>
-    </li>
-    <div class="nhsuk-body-m nhsuk-u-padding-top-2 nhsuk-u-padding-bottom-2 nhsuk-u-padding-left-3 nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-0 border-left-inset-neutral">
-      <p class="nhsuk-u-font-size-16 nhsuk-u-margin-bottom-0">
-        For transparency reasons, all messages can be seen and replied to by everyone who has access to this innovation, including the innovator.
-      </p>
-    </div>
+    <ng-container *ngIf="innovationStatus !== 'ARCHIVED'">
+      <li>
+        <p><a routerLink="/{{ baseUrl }}/innovations/{{ innovationId }}/threads/{{ suggestion.thread.id }}">Send a reply in messages</a></p>
+      </li>
+      <div class="nhsuk-body-m nhsuk-u-padding-top-2 nhsuk-u-padding-bottom-2 nhsuk-u-padding-left-3 nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-0 border-left-inset-neutral">
+        <p class="nhsuk-u-font-size-16 nhsuk-u-margin-bottom-0">
+          For transparency reasons, all messages can be seen and replied to by everyone who has access to this innovation, including the innovator.
+        </p>
+      </div>
+    </ng-container>
   </ul>
 </div>


### PR DESCRIPTION
- Removes thread link and inset on suggestion card when innovation has been archived. 
- Removes endpoint call, when logged as Accessor.

Screenshot:
![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/4017664/8e358d97-3075-4913-a85b-c9f25c1f1825)
