### PR TITLE
Fix logic to display 'Mark this innovation as exempt from KPI reports' link

### DIFF
--- a/src/modules/feature-modules/assessment/pages/innovation/overview/overview.component.ts
+++ b/src/modules/feature-modules/assessment/pages/innovation/overview/overview.component.ts
@@ -144,8 +144,9 @@ export class InnovationOverviewComponent extends CoreComponent implements OnInit
       .subscribe(([assessmentExemption, statistics]) => {
         if (assessmentExemption?.isExempted && assessmentExemption?.exemption) {
           this.assessmentExemption = assessmentExemption.exemption;
-          this.showAssessmentExemptionLink = !assessmentExemption && this.innovation?.assessment?.minorVersion === 0;
         }
+
+        this.showAssessmentExemptionLink = !this.assessmentExemption && this.innovation?.assessment?.minorVersion === 0;
 
         this.cardsList = [
           {


### PR DESCRIPTION
Bug number 19 at "(Re)assessment bugs" document.