### PR TITLE
Set assessment resolver to always run

### DIFF
--- a/src/modules/feature-modules/assessment/assessment-routing.module.ts
+++ b/src/modules/feature-modules/assessment/assessment-routing.module.ts
@@ -182,6 +182,7 @@ const routes: Routes = [
                     resolve: {
                       innovationAssessmentData: mapToResolve(InnovationAssessmentDataResolver)
                     },
+                    runGuardsAndResolvers: 'always',
                     children: [
                       {
                         path: '',


### PR DESCRIPTION
Bug number 10 and 12 at "(Re)assessment bugs" document.

Assessment at context store was being cleaned when navigating between first step and second step of assessment flow and not being reloaded.
