### PR TITLE
Add id to textarea, not to theme-form-textarea component

### DIFF
--- a/src/modules/feature-modules/assessment/pages/innovation/assessment/assessment-edit-reason.component.html
+++ b/src/modules/feature-modules/assessment/pages/innovation/assessment/assessment-edit-reason.component.html
@@ -6,7 +6,7 @@
       </p>
 
       <form [formGroup]="form" (ngSubmit)="onSubmit()">
-        <theme-form-textarea id="reason" controlName="reason" label="Explain reason" lengthLimit="xl" [pageUniqueField]="false"></theme-form-textarea>
+        <theme-form-textarea [id]="'reason'" controlName="reason" label="Explain reason" lengthLimit="xl" [pageUniqueField]="false"></theme-form-textarea>
 
         <button [disabled]="!submitButton.isActive" type="submit" class="nhsuk-button nhsuk-u-margin-top-3">{{ submitButton.label }}</button>
       </form>


### PR DESCRIPTION
Same id was being added to theme-form-textarea component and also to textarea itself.

Bug number 30 at "(Re)assessment bugs" document.