### PR TITLE
A/QA changes to allow access during reassessments

### DIFF
--- a/src/modules/feature-modules/accessor/base/context-innovation-outlet.component.ts
+++ b/src/modules/feature-modules/accessor/base/context-innovation-outlet.component.ts
@@ -3,9 +3,9 @@ import { NavigationEnd, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
+import { UtilsHelper } from '@app/base/helpers';
 import { ContextStore } from '@modules/stores';
 import { InnovationStatusEnum } from '@modules/stores/innovation/innovation.enums';
-import { UtilsHelper } from '@app/base/helpers';
 
 @Component({
   selector: 'app-base-context-innovation-outlet',
@@ -50,7 +50,7 @@ export class ContextInnovationOutletComponent implements OnDestroy {
     if ((event && event.url.includes(`/assessments/`)) || innovation.status === 'ARCHIVED') {
       this.data.link = null;
     } else {
-      if (innovation.assessment) {
+      if (innovation.status === InnovationStatusEnum.IN_PROGRESS && innovation.assessment) {
         const assessmentType = innovation.assessment.majorVersion > 1 ? 'reassessment' : 'assessment';
 
         this.data.link = {

--- a/src/modules/feature-modules/accessor/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/accessor/base/sidebar-innovation-menu-outlet.component.ts
@@ -3,9 +3,9 @@ import { NavigationEnd, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
+import { ViewportScroller } from '@angular/common';
 import { AuthenticationStore, ContextStore, InnovationRecordSchemaStore, InnovationStore } from '@modules/stores';
 import { InnovationStatusEnum } from '@modules/stores/innovation';
-import { ViewportScroller } from '@angular/common';
 
 @Component({
   selector: 'app-base-sidebar-innovation-menu-outlet',
@@ -66,8 +66,7 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
         ...(innovation.status !== InnovationStatusEnum.CREATED
           ? [{ label: 'Documents', url: `/accessor/innovations/${innovation.id}/documents` }]
           : []),
-        ...(innovation.status === InnovationStatusEnum.IN_PROGRESS ||
-        innovation.status === InnovationStatusEnum.ARCHIVED
+        ...(innovation.hasBeenAssessed
           ? [{ label: 'Support summary', url: `/accessor/innovations/${innovation.id}/support-summary` }]
           : []),
         {

--- a/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.html
+++ b/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.html
@@ -19,7 +19,7 @@
             label="{{ 'shared.catalog.innovation.support_status.' + innovationSupport.status + '.name' | translate }}"
           ></theme-tag>
         </dd>
-        <dd *ngIf="!isArchived" class="nhsuk-summary-list__actions width-25">
+        <dd *ngIf="isInProgress" class="nhsuk-summary-list__actions width-25">
           <a
             *ngIf="isQualifyingAccessorRole && innovationSupport.status !== 'UNASSIGNED'"
             routerLink="/accessor/innovations/{{ innovationId }}/support/{{ innovation.support?.id || 'new' }}"
@@ -40,7 +40,7 @@
         </dd>
         <dd class="nhsuk-summary-list__actions">
           <a
-            *ngIf="isQualifyingAccessorRole && innovationSupport.status === 'ENGAGING'"
+            *ngIf="isInProgress && isQualifyingAccessorRole && innovationSupport.status === 'ENGAGING'"
             routerLink="/accessor/innovations/{{ innovationId }}/support/{{ innovation.support?.id || 'new' }}/change-accessors"
             >Change accessors</a
           >
@@ -54,14 +54,20 @@
   </div>
 
   <a
-    *ngIf="!isArchived && isQualifyingAccessorRole && innovationSupport.status === 'UNASSIGNED'"
+    *ngIf="isInProgress && isQualifyingAccessorRole && innovationSupport.status === 'UNASSIGNED'"
     routerLink="/accessor/innovations/{{ innovationId }}/support/{{ innovation.support?.id || 'new' }}"
     class="nhsuk-button nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-5"
   >
     Change support status
   </a>
 
-  <ng-container *ngIf="isAccessorRole && !isArchived">
+  <div *ngIf="isInAssessment" class="nhsuk-inset-text nhsuk-u-margin-top-0">
+    <span class="nhsuk-u-visually-hidden">Information:</span>
+    <p>The needs assessment team are editing this innovation's needs assessment. 
+    Messages, tasks, support update and suggestions will be unavailable on this innovation until the update is submitted.</p>
+  </div>
+
+  <ng-container *ngIf="isAccessorRole && isInProgress">
     <a routerLink="/accessor/innovations/{{ innovationId }}/support/{{ innovation.support?.id }}/request-update" class="nhsuk-button nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-3"
       >Request status update</a
     >

--- a/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovation/overview/overview.component.ts
@@ -7,7 +7,7 @@ import { ContextInnovationType, StatisticsCardType } from '@app/base/types';
 
 import { NotificationContextDetailEnum } from '@modules/stores/context/context.enums';
 import { irVersionsMainCategoryItems } from '@modules/stores/innovation/innovation-record/ir-versions.config';
-import { InnovationSupportStatusEnum } from '@modules/stores/innovation/innovation.enums';
+import { InnovationStatusEnum, InnovationSupportStatusEnum } from '@modules/stores/innovation/innovation.enums';
 
 import { InnovationCollaboratorsListDTO } from '@modules/shared/services/innovations.dtos';
 import { InnovationsService } from '@modules/shared/services/innovations.service';
@@ -39,6 +39,8 @@ export class InnovationOverviewComponent extends CoreComponent implements OnInit
     engagingAccessors: { name: string }[];
   } = { organisationUnit: '', status: InnovationSupportStatusEnum.UNASSIGNED, engagingAccessors: [] };
 
+  isInProgress: boolean = false;
+  isInAssessment: boolean = false;
   isArchived: boolean = false;
   showCards: boolean = false;
 
@@ -60,6 +62,12 @@ export class InnovationOverviewComponent extends CoreComponent implements OnInit
     this.innovation = this.stores.context.getInnovation();
     this.isQualifyingAccessorRole = this.stores.authentication.isQualifyingAccessorRole();
     this.isAccessorRole = this.stores.authentication.isAccessorRole();
+    this.isInAssessment = [
+      InnovationStatusEnum.AWAITING_NEEDS_REASSESSMENT,
+      InnovationStatusEnum.NEEDS_ASSESSMENT,
+      InnovationStatusEnum.WAITING_NEEDS_ASSESSMENT
+    ].includes(this.innovation.status);
+    this.isInProgress = this.innovation.status === 'IN_PROGRESS';
     this.isArchived = this.innovation.status === 'ARCHIVED';
 
     this.setPageTitle('Overview', { hint: `Innovation ${this.innovation.name}` });

--- a/src/modules/feature-modules/accessor/pages/innovations/innovations-review.component.html
+++ b/src/modules/feature-modules/accessor/pages/innovations/innovations-review.component.html
@@ -92,17 +92,23 @@
                 <div class="d-flex">
                   <div class="nhsuk-u-padding-right-1">
                     <span class="nhsuk-table-responsive__heading">{{ innovationsList.getColumnLabel("name") }} </span>
-                    <a
-                      *ngIf="item.support?.status !== 'ENGAGING' && item.assessment?.id"
-                      routerLink="/accessor/innovations/{{ item.id }}/assessments/{{ item.assessment?.id }}"
-                      attr.aria-label="View {{ item.name }} innovation assessment details"
-                    >
-                      {{ item.name }}
-                    </a>
-                    <span *ngIf="(item.support?.status !== 'ENGAGING' && !item.assessment?.id) || item.support?.closedReason?.value === 'STOPPED_SHARED'"> {{ item.name }} </span>
-                    <a *ngIf="item.support?.status === 'ENGAGING'" routerLink="/accessor/innovations/{{ item.id }}" attr.aria-label="View {{ item.name }} innovation">
-                      {{ item.name }}
-                    </a>
+                    <ng-container *ngIf="(item.support?.status !== 'ENGAGING' && !item.assessment?.id) || item.support?.closedReason?.value === 'STOPPED_SHARED' ; else hasLink">
+                      <span> {{ item.name }} </span>
+                    </ng-container>
+                    <ng-template #hasLink>
+                      <a
+                        *ngIf="item.assessment?.finishedAt && item.assessment?.id ; else noAssessment"
+                        routerLink="/accessor/innovations/{{ item.id }}/assessments/{{ item.assessment?.id }}"
+                        attr.aria-label="View {{ item.name }} innovation assessment details"
+                      >
+                        {{ item.name }}
+                      </a>
+                      <ng-template #noAssessment>
+                        <a routerLink="/accessor/innovations/{{ item.id }}" attr.aria-label="View {{ item.name }} innovation">
+                          {{ item.name }}
+                        </a>
+                      </ng-template>
+                    </ng-template>
                   </div>
                   <theme-notification-tag *ngIf="item.notifications" [label]="item.notifications"></theme-notification-tag>
                 </div>

--- a/src/modules/feature-modules/accessor/pages/innovations/innovations-review.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovations/innovations-review.component.ts
@@ -64,6 +64,7 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
       accessors: string[];
       assessment: {
         id: string;
+        finishedAt: DateISOType | null;
       } | null;
       notifications: number;
       engagingOrganisations: string[];
@@ -114,6 +115,7 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
             'updatedAt',
             'mainCategory',
             'assessment.id',
+            'assessment.finishedAt',
             'support.status',
             'support.updatedAt',
             'statistics.notifications',
@@ -137,6 +139,7 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
             'id',
             'name',
             'assessment.id',
+            'assessment.finishedAt',
             'support.status',
             'support.updatedAt',
             'support.updatedBy',
@@ -166,6 +169,7 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
             'countryName',
             'mainCategory',
             'assessment.id',
+            'assessment.finishedAt',
             'support.status',
             'statistics.notifications'
           ],
@@ -189,6 +193,7 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
             'countryName',
             'mainCategory',
             'assessment.id',
+            'assessment.finishedAt',
             'support.status',
             'statistics.notifications',
             'engagingOrganisations',
@@ -211,6 +216,7 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
             'name',
             'mainCategory',
             'assessment.id',
+            'assessment.finishedAt',
             'support.status',
             'support.updatedAt',
             'statistics.notifications',
@@ -234,6 +240,7 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
             'countryName',
             'mainCategory',
             'assessment.id',
+            'assessment.finishedAt',
             'support.status',
             'support.updatedAt',
             'statistics.notifications',
@@ -256,6 +263,7 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
             'countryName',
             'mainCategory',
             'assessment.id',
+            'assessment.finishedAt',
             'support.status',
             'support.updatedAt',
             'statistics.notifications',
@@ -278,6 +286,7 @@ export class InnovationsReviewComponent extends CoreComponent implements OnInit 
             'id',
             'name',
             'assessment.id',
+            'assessment.finishedAt',
             'support.status',
             'support.updatedAt',
             'support.updatedBy',

--- a/src/modules/feature-modules/admin/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/admin/base/sidebar-innovation-menu-outlet.component.ts
@@ -59,9 +59,9 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
         innovation.archivedStatus !== InnovationStatusEnum.CREATED
           ? [{ label: 'Documents', url: `/admin/innovations/${innovation.id}/documents` }]
           : []),
-        ...(innovation.assessment?.finishedAt == null && innovation.reassessmentCount === 0
-          ? []
-          : [{ label: 'Support summary', url: `/admin/innovations/${innovation.id}/support-summary` }]),
+        ...(innovation.hasBeenAssessed
+          ? [{ label: 'Support summary', url: `/admin/innovations/${innovation.id}/support-summary` }]
+          : []),
         { label: 'Data sharing preferences', url: `/admin/innovations/${innovation.id}/support` },
         { label: 'Activity log', url: `/admin/innovations/${innovation.id}/activity-log` }
       ];

--- a/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/assessment/base/sidebar-innovation-menu-outlet.component.ts
@@ -3,9 +3,9 @@ import { NavigationEnd, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
+import { ViewportScroller } from '@angular/common';
 import { ContextStore, InnovationRecordSchemaStore, InnovationStore } from '@modules/stores';
 import { InnovationStatusEnum } from '@modules/stores/innovation/innovation.enums';
-import { ViewportScroller } from '@angular/common';
 
 @Component({
   selector: 'app-base-sidebar-innovation-menu-outlet',
@@ -62,9 +62,9 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
         ...(innovation.status !== InnovationStatusEnum.CREATED
           ? [{ label: 'Documents', url: `/assessment/innovations/${innovation.id}/documents` }]
           : []),
-        ...(innovation.assessment?.finishedAt == null && innovation.reassessmentCount === 0
-          ? []
-          : [{ label: 'Support summary', url: `/assessment/innovations/${innovation.id}/support-summary` }]),
+        ...(innovation.hasBeenAssessed
+          ? [{ label: 'Support summary', url: `/assessment/innovations/${innovation.id}/support-summary` }]
+          : []),
         { label: 'Data sharing preferences', url: `/assessment/innovations/${innovation.id}/support` },
         { label: 'Activity log', url: `/assessment/innovations/${innovation.id}/activity-log` }
       ];

--- a/src/modules/feature-modules/innovator/base/sidebar-innovation-menu-outlet.component.ts
+++ b/src/modules/feature-modules/innovator/base/sidebar-innovation-menu-outlet.component.ts
@@ -2,9 +2,9 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 
+import { ViewportScroller } from '@angular/common';
 import { ContextStore, InnovationRecordSchemaStore, InnovationStore } from '@modules/stores';
 import { InnovationStatusEnum } from '@modules/stores/innovation';
-import { ViewportScroller } from '@angular/common';
 
 @Component({
   selector: 'app-base-sidebar-innovation-menu-outlet',
@@ -60,8 +60,7 @@ export class SidebarInnovationMenuOutletComponent implements OnInit, OnDestroy {
         innovation.archivedStatus !== InnovationStatusEnum.CREATED
           ? [{ label: 'Documents', url: `/innovator/innovations/${innovation.id}/documents` }]
           : []),
-        ...(innovation.status === InnovationStatusEnum.IN_PROGRESS ||
-        innovation.archivedStatus === InnovationStatusEnum.IN_PROGRESS
+        ...(innovation.hasBeenAssessed
           ? [{ label: 'Support summary', url: `/innovator/innovations/${innovation.id}/support-summary` }]
           : []),
         { label: 'Data sharing preferences', url: `/innovator/innovations/${innovation.id}/support` },

--- a/src/modules/shared/pages/innovation/data-sharing-and-support/data-sharing-and-support.component.html
+++ b/src/modules/shared/pages/innovation/data-sharing-and-support/data-sharing-and-support.component.html
@@ -135,6 +135,12 @@
           Change preferences
         </button>
 
+        <div *ngIf="isQualifyingAccessorRole && innovation.status.includes('ASSESSMENT')" class="nhsuk-inset-text nhsuk-u-margin-top-0">
+          <span class="nhsuk-u-visually-hidden">Information:</span>
+          <p>The needs assessment team are editing this innovation's needs assessment. 
+          Messages, tasks, support update and suggestions will be unavailable on this innovation until the update is submitted.</p>
+        </div>
+
         <div *ngIf="isQualifyingAccessorRole && showSuggestOrganisationsToSupportLink" class="nhsuk-action-link nhsuk-u-padding-top-5">
           <a routerLink="/accessor/innovations/{{ innovationId }}/support/suggest" class="nhsuk-action-link__link">
             <theme-svg-icon type="arrow-right-circle" />

--- a/src/modules/shared/pages/innovation/data-sharing-and-support/data-sharing-and-support.component.ts
+++ b/src/modules/shared/pages/innovation/data-sharing-and-support/data-sharing-and-support.component.ts
@@ -5,14 +5,14 @@ import { ObservableInput, forkJoin } from 'rxjs';
 import { CoreComponent } from '@app/base';
 import { NotificationContextDetailEnum, UserRoleEnum } from '@app/base/enums';
 
+import { ContextInnovationType } from '@modules/stores/context/context.types';
 import { InnovationService, InnovationStatusEnum, InnovationSupportStatusEnum } from '@modules/stores/innovation';
 import { OrganisationSuggestionModel } from '@modules/stores/innovation/innovation.models';
-import { ContextInnovationType } from '@modules/stores/context/context.types';
 
-import { InnovationsService } from '@modules/shared/services/innovations.service';
-import { InnovationSharesListDTO, InnovationSupportsListDTO } from '@modules/shared/services/innovations.dtos';
-import { OrganisationsListDTO, OrganisationsService } from '@modules/shared/services/organisations.service';
 import { UtilsHelper } from '@app/base/helpers';
+import { InnovationSharesListDTO, InnovationSupportsListDTO } from '@modules/shared/services/innovations.dtos';
+import { InnovationsService } from '@modules/shared/services/innovations.service';
+import { OrganisationsListDTO, OrganisationsService } from '@modules/shared/services/organisations.service';
 
 @Component({
   selector: 'shared-pages-innovation-data-sharing-and-support',
@@ -260,12 +260,14 @@ export class PageInnovationDataSharingAndSupportComponent extends CoreComponent 
           .filter(support => support.status === InnovationSupportStatusEnum.ENGAGING)
           .map(support => support.organisation.unit.id);
 
-        this.showSuggestOrganisationsToSupportLink = !!UtilsHelper.getAvailableOrganisationsToSuggest(
-          this.innovation.id,
-          userUnitId,
-          results.organisationsList,
-          engagingUnitsIds
-        ).length;
+        this.showSuggestOrganisationsToSupportLink =
+          this.innovation.status === InnovationStatusEnum.IN_PROGRESS &&
+          !!UtilsHelper.getAvailableOrganisationsToSuggest(
+            this.innovation.id,
+            userUnitId,
+            results.organisationsList,
+            engagingUnitsIds
+          ).length;
       }
 
       this.setPageStatus('READY');

--- a/src/modules/shared/pages/innovation/messages/thread-messages-list.component.html
+++ b/src/modules/shared/pages/innovation/messages/thread-messages-list.component.html
@@ -7,6 +7,12 @@
           <a routerLink="/{{ selfUser.urlBasePath }}/innovations/{{ innovation.id }}/tasks/{{ threadInfo?.context?.id }}">Go to task</a>
         </p>
 
+        <div *ngIf="isAccessorType && isInAssessment" class="nhsuk-inset-text nhsuk-u-margin-top-0">
+          <span class="nhsuk-u-visually-hidden">Information:</span>
+          <p>The needs assessment team are editing this innovation's needs assessment. 
+          Messages, tasks, support update and suggestions will be unavailable on this innovation until the update is submitted.</p>
+        </div>
+
         <ng-container *ngIf="(isAssessmentType || isAccessorType) && !isArchived">
           <p *ngIf="isFollower" class="nhsuk-u-font-size-16">
             <a href="javascript:void(0)" (click)="onUnfollowMessageThreadClick()">Unfollow this message thread</a> if you do not want to be notified about new replies.
@@ -45,7 +51,7 @@
 
           <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-2" />
 
-          <form [formGroup]="form" (ngSubmit)="onSubmit()" *ngIf="isAdmin === false">
+          <form *ngIf="canCreateMessage" [formGroup]="form" (ngSubmit)="onSubmit()">
             <theme-form-textarea controlName="message" description="Write a message" [pageUniqueField]="false" lengthLimit="xxl"></theme-form-textarea>
 
             <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">Upload a document (optional)</h2>
@@ -64,7 +70,7 @@
             </button>
           </form>
 
-          <div class="nhsuk-body-m nhsuk-u-padding-top-2 nhsuk-u-padding-bottom-2 nhsuk-u-padding-left-3 nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-5 border-left-inset-neutral">
+          <div *ngIf="canCreateMessage" class="nhsuk-body-m nhsuk-u-padding-top-2 nhsuk-u-padding-bottom-2 nhsuk-u-padding-left-3 nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-5 border-left-inset-neutral">
             <span class="nhsuk-u-visually-hidden">Information: </span>
             <span
               >Once sent, all recipients in this thread will be notified. For transparency reasons, this message can be seen and replied to by everyone who has access to this

--- a/src/modules/shared/pages/innovation/messages/thread-messages-list.component.ts
+++ b/src/modules/shared/pages/innovation/messages/thread-messages-list.component.ts
@@ -1,4 +1,3 @@
-import { UserRoleEnum } from './../../../../stores/authentication/authentication.enums';
 import { Component, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
@@ -70,6 +69,8 @@ export class PageInnovationThreadMessagesListComponent extends CoreComponent imp
   isAdmin: boolean;
   isFollower: boolean = false;
   isArchived: boolean;
+  isInAssessment: boolean;
+  canCreateMessage: boolean;
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -113,6 +114,9 @@ export class PageInnovationThreadMessagesListComponent extends CoreComponent imp
     this.isAccessorType = this.stores.authentication.isAccessorType();
     this.isAdmin = this.stores.authentication.isAdminRole();
     this.isArchived = this.innovation.status === InnovationStatusEnum.ARCHIVED;
+    this.isInAssessment = this.innovation.status.includes('ASSESSMENT');
+
+    this.canCreateMessage = !this.isAdmin && (!this.isAccessorType || !this.isInAssessment);
   }
 
   ngOnInit(): void {

--- a/src/modules/shared/pages/innovation/messages/threads-list.component.html
+++ b/src/modules/shared/pages/innovation/messages/threads-list.component.html
@@ -40,6 +40,12 @@
         </div>
         <button type="button" routerLink="new" class="nhsuk-button">Start a new thread</button>
       </ng-container>
+
+      <div *ngIf="isAccessorType && isInAssessment" class="nhsuk-inset-text nhsuk-u-margin-top-0">
+        <span class="nhsuk-u-visually-hidden">Information:</span>
+        <p>The needs assessment team are editing this innovation's needs assessment. 
+        Messages, tasks, support update and suggestions will be unavailable on this innovation until the update is submitted.</p>
+      </div>
     </div>
 
     <div class="nhsuk-grid-column-full">

--- a/src/modules/shared/pages/innovation/messages/threads-list.component.ts
+++ b/src/modules/shared/pages/innovation/messages/threads-list.component.ts
@@ -31,10 +31,12 @@ export class PageInnovationThreadsListComponent extends CoreComponent implements
 
   // Flags
   isInnovatorType: boolean;
+  isAccessorType: boolean;
   isAdmin: boolean;
   isInnovationSubmitted: boolean;
   canCreateThread: boolean = false;
   isArchived: boolean;
+  isInAssessment: boolean;
 
   constructor(private innovationsService: InnovationsService) {
     super();
@@ -50,11 +52,16 @@ export class PageInnovationThreadsListComponent extends CoreComponent implements
     // Flags
     this.isInnovatorType = this.stores.authentication.isInnovatorType();
     this.isAdmin = this.stores.authentication.isAdminRole();
+    this.isAccessorType = this.stores.authentication.isAccessorType();
     this.isInnovationSubmitted = this.innovation.status !== InnovationStatusEnum.CREATED;
     this.isArchived = this.innovation.status === InnovationStatusEnum.ARCHIVED;
+    this.isInAssessment = this.innovation.status.includes('ASSESSMENT');
 
-    if (this.stores.authentication.isAssessmentType() || this.stores.authentication.isAccessorType()) {
+    if (this.stores.authentication.isAssessmentType()) {
       this.canCreateThread = this.innovation.owner != null;
+    } else if (this.stores.authentication.isAccessorType()) {
+      this.canCreateThread =
+        this.innovation.owner != null && this.innovation.status === InnovationStatusEnum.IN_PROGRESS;
     } else if (this.stores.authentication.isInnovatorType()) {
       if (
         this.innovation.status === InnovationStatusEnum.IN_PROGRESS ||

--- a/src/modules/shared/pages/innovation/sections/section-info-all.component.html
+++ b/src/modules/shared/pages/innovation/sections/section-info-all.component.html
@@ -107,7 +107,7 @@
 
     <ng-container
       *ngIf="
-        ((innovation.support?.status === 'ENGAGING' || innovation.support?.status === 'WAITING') && isAccessorType) ||
+        (innovation.status==='IN_PROGRESS' && (innovation.support?.status === 'ENGAGING' || innovation.support?.status === 'WAITING') && isAccessorType) ||
         (['NEEDS_ASSESSMENT', 'IN_PROGRESS'].includes(innovation.status) && isAssessmentType)
       "
     >

--- a/src/modules/shared/pages/innovation/sections/section-info.component.html
+++ b/src/modules/shared/pages/innovation/sections/section-info.component.html
@@ -120,7 +120,7 @@
 
       <ng-container
         *ngIf="
-          ((innovation.support?.status === 'ENGAGING' || innovation.support?.status === 'WAITING') && isAccessorType) ||
+          (innovation.status==='IN_PROGRESS' && (innovation.support?.status === 'ENGAGING' || innovation.support?.status === 'WAITING') && isAccessorType) ||
           (['NEEDS_ASSESSMENT', 'IN_PROGRESS'].includes(innovation.status) && isAssessmentType)
         "
       >

--- a/src/modules/shared/pages/innovation/tasks/task-details.component.html
+++ b/src/modules/shared/pages/innovation/tasks/task-details.component.html
@@ -124,7 +124,7 @@
             <ul class="nhsuk-list">
               <li>
                 <a
-                  *ngIf="!isArchived && ['DONE', 'DECLINED'].includes(task.status) && task.sameOrganisation"
+                  *ngIf="canReopen"
                   routerLink="/{{ userUrlBase }}/innovations/{{ innovationId }}/tasks/{{ task.id }}/reopen"
                   class="nhsuk-button nhsuk-u-margin-right-3 nhsuk-u-margin-bottom-3"
                 >
@@ -133,7 +133,7 @@
               </li>
               <li>
                 <a
-                  *ngIf="task.status === 'OPEN' && task.sameOrganisation"
+                  *ngIf="canCancel"
                   routerLink="/{{ userUrlBase }}/innovations/{{ innovationId }}/tasks/{{ task.id }}/cancel"
                   class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-3"
                 >

--- a/src/modules/shared/pages/innovation/tasks/task-details.component.ts
+++ b/src/modules/shared/pages/innovation/tasks/task-details.component.ts
@@ -6,7 +6,7 @@ import { InnovationDescription, InnovationTaskInfoDTO } from '@modules/shared/se
 import { InnovationsService } from '@modules/shared/services/innovations.service';
 
 import { NotificationContextDetailEnum } from '@modules/stores/context/context.enums';
-import { InnovationSectionEnum, InnovationStatusEnum, InnovationTaskStatusEnum } from '@modules/stores/innovation';
+import { InnovationSectionEnum, InnovationStatusEnum } from '@modules/stores/innovation';
 
 @Component({
   selector: 'shared-pages-innovation-task-section-info',
@@ -32,6 +32,10 @@ export class PageInnovationTaskDetailsComponent extends CoreComponent implements
   isAssessmentType: boolean;
   isAdmin: boolean;
   isArchived: boolean;
+  canReopen = false;
+  canCancel = false;
+
+  readonly innovation = this.stores.context.getInnovation();
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -144,7 +148,24 @@ export class PageInnovationTaskDetailsComponent extends CoreComponent implements
         });
       }
 
+      this.setAllowedActions();
+
       this.setPageStatus('READY');
     });
+  }
+
+  private setAllowedActions() {
+    this.canReopen =
+      !!this.task &&
+      !this.isArchived &&
+      ['DONE', 'DECLINED'].includes(this.task.status) &&
+      this.task.sameOrganisation &&
+      (this.isAssessmentType || (this.isAccessorType && this.innovation.status === InnovationStatusEnum.IN_PROGRESS));
+
+    this.canCancel =
+      !!this.task &&
+      this.task.status === 'OPEN' &&
+      this.task.sameOrganisation &&
+      (this.isAssessmentType || (this.isAccessorType && this.innovation.status === InnovationStatusEnum.IN_PROGRESS));
   }
 }

--- a/src/modules/shared/pages/innovation/tasks/task-to-do-list.component.html
+++ b/src/modules/shared/pages/innovation/tasks/task-to-do-list.component.html
@@ -26,8 +26,13 @@
     </ng-container>
 
     <ng-container *ngSwitchCase="'ACCESSOR'">
-      <ng-container *ngIf="innovation.support?.status === 'ENGAGING' || innovation.support?.status === 'WAITING'; then requestActionBtn"></ng-container>
-
+      <ng-container *ngIf="innovation.status === 'IN_PROGRESS' && (innovation.support?.status === 'ENGAGING' || innovation.support?.status === 'WAITING'); then requestActionBtn"></ng-container>
+      <div *ngIf="innovation.status.includes('ASSESSMENT')" class="nhsuk-inset-text nhsuk-u-margin-top-0">
+        <span class="nhsuk-u-visually-hidden">Information:</span>
+        <p>The needs assessment team are editing this innovation's needs assessment. 
+        Messages, tasks, support update and suggestions will be unavailable on this innovation until the update is submitted.</p>
+      </div>
+        
       <ng-container *ngTemplateOutlet="actionTrackerList"></ng-container>
     </ng-container>
 

--- a/src/modules/shared/services/innovations.dtos.ts
+++ b/src/modules/shared/services/innovations.dtos.ts
@@ -153,6 +153,7 @@ export type InnovationInfoDTO = {
   status: InnovationStatusEnum;
   archivedStatus?: InnovationStatusEnum;
   groupedStatus: InnovationGroupedStatusEnum;
+  hasBeenAssessed: boolean;
   submittedAt: null | DateISOType;
   countryName: null | string;
   postCode: null | string;

--- a/src/modules/shared/services/innovations.dtos.ts
+++ b/src/modules/shared/services/innovations.dtos.ts
@@ -87,6 +87,7 @@ export type InnovationListSelectType =
   | 'assessment.minorVersion'
   | 'assessment.assignedTo'
   | 'assessment.isExempt'
+  | 'assessment.finishedAt'
   | 'assessment.updatedAt'
   | 'statistics.notifications'
   | 'statistics.tasks'
@@ -134,6 +135,7 @@ export type InnovationListFullDTO = {
     majorVersion: number;
     minorVersion: number;
     assignedTo: string | null;
+    finishedAt: DateISOType | null;
     updatedAt: DateISOType;
     isExempt: boolean;
   } | null;

--- a/src/modules/stores/context/context.service.ts
+++ b/src/modules/stores/context/context.service.ts
@@ -119,6 +119,7 @@ export class ContextService {
               ? InnovationStatusEnum.AWAITING_NEEDS_REASSESSMENT
               : response.status,
           statusUpdatedAt: response.statusUpdatedAt,
+          hasBeenAssessed: response.hasBeenAssessed,
           archivedStatus: response.archivedStatus,
           ...(response.owner
             ? {

--- a/src/modules/stores/context/context.store.ts
+++ b/src/modules/stores/context/context.store.ts
@@ -185,6 +185,7 @@ export class ContextStore extends Store<ContextModel> {
         name: '',
         status: InnovationStatusEnum.CREATED,
         statusUpdatedAt: null,
+        hasBeenAssessed: false,
         loggedUser: { isOwner: false },
         reassessmentCount: 0,
         categories: [],

--- a/src/modules/stores/context/context.types.ts
+++ b/src/modules/stores/context/context.types.ts
@@ -1,9 +1,9 @@
 import { DateISOType, LinkType } from '@app/base/types';
 import { InnovationStatusEnum, InnovationSupportStatusEnum } from '../innovation/innovation.enums';
 
+import { ReassessmentSendType } from '@modules/feature-modules/innovator/pages/innovation/needs-reassessment/needs-reassessment-send.config';
 import { InnovationRecordSchemaInfoType } from '../innovation/innovation-record/innovation-record-schema/innovation-record-schema.models';
 import { NotificationCategoryTypeEnum } from './context.enums';
-import { ReassessmentSendType } from '@modules/feature-modules/innovator/pages/innovation/needs-reassessment/needs-reassessment-send.config';
 
 export type ContextPageAlertType = {
   type: null | 'ACTION' | 'INFORMATION' | 'SUCCESS' | 'WARNING' | 'ERROR';
@@ -51,6 +51,7 @@ export type ContextInnovationType = {
   status: InnovationStatusEnum;
   statusUpdatedAt: null | DateISOType;
   archivedStatus?: InnovationStatusEnum;
+  hasBeenAssessed: boolean;
   countryName: string | null;
   description: string | null;
   postCode: string | null;

--- a/src/tests/data.mocks.ts
+++ b/src/tests/data.mocks.ts
@@ -100,6 +100,7 @@ export const CONTEXT_INNOVATION_INFO: ContextInnovationType = {
   statusUpdatedAt: '2020-01-01T00:00:00.000Z',
   owner: { name: 'User name 01', isActive: true },
   loggedUser: { isOwner: true },
+  hasBeenAssessed: false,
   assessment: {
     id: 'assessment01',
     majorVersion: 1,


### PR DESCRIPTION
Changes:
* changes to list innovations that have already had an assessment
* changes to elastic search for innovations that had an assessment
* forbid support update/create
* forbid task update/create
* forbid thread/message update/create
* forbid suggestions
* fix support summary not showing while in reassessment

Inset:
![image](https://github.com/user-attachments/assets/b1464252-baf3-4db0-b107-d5de7f4e78c8)
