### PR TITLE
delete an account through Admin portal

### DIFF
--- a/src/modules/feature-modules/admin/admin-routing.module.ts
+++ b/src/modules/feature-modules/admin/admin-routing.module.ts
@@ -85,6 +85,7 @@ import { InnovationTaskDataResolver } from '@modules/shared/resolvers/innovation
 import { InnovationThreadDataResolver } from '@modules/shared/resolvers/innovation-thread-data.resolver';
 import { PageUserDeleteComponent } from './pages/users/user-delete.component';
 import { PageUserEmailComponent } from './pages/users/user-email.component';
+import { PageUserManageComponent } from './pages/users/user-manage.component';
 import { AnnouncementDataResolver } from './resolvers/announcement-data.resolver';
 import { OrganisationDataResolver } from './resolvers/organisation-data.resolver';
 import { OrganisationUnitDataResolver } from './resolvers/organisation-unit-data.resolver';
@@ -255,6 +256,16 @@ const routes: Routes = [
                 pathMatch: 'full',
                 component: PageUsersRoleChangeComponent,
                 data: { breadcrumb: null }
+              },
+              {
+                path: 'manage',
+                data: { breadcrumb: 'Manage account' },
+                children: [
+                  { path: '', pathMatch: 'full', component: PageUserManageComponent, data: { breadcrumb: null } },
+                  { path: 'delete', pathMatch: 'full', component: PageUserDeleteComponent, data: { breadcrumb: null } },
+                  { path: 'lock', pathMatch: 'full', component: PageUserLockComponent, data: { breadcrumb: null } },
+                  { path: 'unlock', pathMatch: 'full', component: PageUserUnlockComponent, data: { breadcrumb: null } }
+                ]
               },
               {
                 path: 'role',

--- a/src/modules/feature-modules/admin/admin-routing.module.ts
+++ b/src/modules/feature-modules/admin/admin-routing.module.ts
@@ -248,7 +248,6 @@ const routes: Routes = [
             children: [
               { path: '', pathMatch: 'full', component: PageUserInfoComponent, data: { breadcrumb: null } },
               { path: 'email', pathMatch: 'full', component: PageUserEmailComponent, data: { breadcrumb: null } },
-              { path: 'delete', pathMatch: 'full', component: PageUserDeleteComponent, data: { breadcrumb: null } },
               { path: 'lock', pathMatch: 'full', component: PageUserLockComponent, data: { breadcrumb: null } },
               { path: 'unlock', pathMatch: 'full', component: PageUserUnlockComponent, data: { breadcrumb: null } },
               {

--- a/src/modules/feature-modules/admin/admin.module.ts
+++ b/src/modules/feature-modules/admin/admin.module.ts
@@ -15,11 +15,12 @@ import { PageUsersRoleActivateComponent } from './pages/users/roles/role-activat
 import { PageUsersRoleChangeComponent } from './pages/users/roles/role-change.component';
 import { PageUsersRoleInactivateComponent } from './pages/users/roles/role-inactivate.component';
 import { PageRoleNewComponent } from './pages/users/roles/role-new.component';
+import { PageUserDeleteComponent } from './pages/users/user-delete.component';
 import { PageUserEmailComponent } from './pages/users/user-email.component';
 import { PageUserFindComponent } from './pages/users/user-find.component';
 import { PageUserInfoComponent } from './pages/users/user-info.component';
-import { PageUserDeleteComponent } from './pages/users/user-delete.component';
 import { PageUserLockComponent } from './pages/users/user-lock.component';
+import { PageUserManageComponent } from './pages/users/user-manage.component';
 import { PageUserNewComponent } from './pages/users/user-new.component';
 import { PageUserUnlockComponent } from './pages/users/user-unlock.component';
 // // Announcements.
@@ -59,16 +60,16 @@ import { UserInformationComponent } from './components/user-information.componen
 // Services.
 import { AdminOrganisationsService } from './services/admin-organisations.service';
 import { AnnouncementsService } from './services/announcements.service';
+import { ElasticSearchService } from './services/elastic-search.service';
 import { UsersValidationRulesService } from './services/users-validation-rules.service';
 import { AdminUsersService } from './services/users.service';
-import { ElasticSearchService } from './services/elastic-search.service';
 
 // Resolvers.
+import { SidebarAccountMenuOutletComponent } from './base/sidebar-account-menu-outlet.component';
 import { AnnouncementDataResolver } from './resolvers/announcement-data.resolver';
 import { OrganisationDataResolver } from './resolvers/organisation-data.resolver';
 import { OrganisationUnitDataResolver } from './resolvers/organisation-unit-data.resolver';
 import { ServiceUserDataResolver } from './resolvers/service-user-data.resolver';
-import { SidebarAccountMenuOutletComponent } from './base/sidebar-account-menu-outlet.component';
 
 @NgModule({
   imports: [ThemeModule, SharedModule, AdminRoutingModule],
@@ -104,6 +105,7 @@ import { SidebarAccountMenuOutletComponent } from './base/sidebar-account-menu-o
     // // Service Users.
     PageUsersRoleChangeComponent,
     PageUserDeleteComponent,
+    PageUserManageComponent,
     PageUserLockComponent,
     PageUserUnlockComponent,
     PageUsersRoleInactivateComponent,

--- a/src/modules/feature-modules/admin/pages/users/user-delete.component.html
+++ b/src/modules/feature-modules/admin/pages/users/user-delete.component.html
@@ -37,11 +37,15 @@
           <span role="text"><span class="nhsuk-u-visually-hidden">Important: </span>Are you sure?</span>
         </div>
         <p>Accounts should only be deleted in exceptional circumstances and users should delete their account if possible.</p>
+        <p>Before you continue, make sure you have an explicit request from the NHS Innovation Service service owner to proceed with the delete account.</p>
       </div>
     </div>
 
     <div class="nhsuk-grid-column-two-thirds">
-      <button type="button" (click)="onSubmit()" class="nhsuk-button nhsuk-u-margin-top-3 nhsuk-u-margin-right-3">Delete user</button>
+      <form [formGroup]="form">
+        <theme-form-input controlName="confirmation" description="To confirm, please type the following: delete user account" [pageUniqueField]="false"></theme-form-input>
+        <button type="button" (click)="onSubmit()" class="nhsuk-button nhsuk-u-margin-top-3 nhsuk-u-margin-right-3">Delete user</button>
+      </form>
     </div>
   </div>
 </theme-content-wrapper>

--- a/src/modules/feature-modules/admin/pages/users/user-delete.component.ts
+++ b/src/modules/feature-modules/admin/pages/users/user-delete.component.ts
@@ -4,6 +4,8 @@ import { ActivatedRoute } from '@angular/router';
 import { CoreComponent } from '@app/base';
 import { RoutingHelper } from '@app/base/helpers';
 
+import { FormGroup, UntypedFormControl } from '@angular/forms';
+import { CustomValidators } from '@app/base/forms';
 import { AdminValidationResponseDTO, UsersValidationRulesService } from '../../services/users-validation-rules.service';
 import { AdminUsersService } from '../../services/users.service';
 
@@ -17,6 +19,16 @@ export class PageUserDeleteComponent extends CoreComponent implements OnInit {
   pageStep: 'RULES' | 'DELETE_USER' = 'RULES';
 
   rulesList: AdminValidationResponseDTO['validations'] = [];
+
+  form = new FormGroup(
+    {
+      confirmation: new UntypedFormControl('', [
+        CustomValidators.required('A confirmation text is necessary'),
+        CustomValidators.equalTo('delete user account')
+      ])
+    },
+    { updateOn: 'blur' }
+  );
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -58,6 +70,11 @@ export class PageUserDeleteComponent extends CoreComponent implements OnInit {
   }
 
   onSubmit(): void {
+    if (!this.form.valid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
     this.usersService.deleteUser(this.user.id).subscribe({
       next: () => this.redirectTo(`/admin/users`, { alert: 'deleteSuccess' }),
       error: () => {

--- a/src/modules/feature-modules/admin/pages/users/user-info.component.html
+++ b/src/modules/feature-modules/admin/pages/users/user-info.component.html
@@ -22,8 +22,6 @@
           <dd class="nhsuk-summary-list__actions">
             <ul class="nhsuk-list">
               <li><a routerLink="manage">Manage account</a></li>
-              <li><a *ngIf="user.isActive" routerLink="{{ action.url }}">{{ action.label }}</a></li>
-              <li><a routerLink="/admin/users/{{ user.id }}/delete">Delete user</a></li>
             </ul>
           </dd>
         </div>

--- a/src/modules/feature-modules/admin/pages/users/user-info.component.html
+++ b/src/modules/feature-modules/admin/pages/users/user-info.component.html
@@ -21,6 +21,7 @@
           <dd class="nhsuk-summary-list__value">{{ user.isActive ? "Active" : "Inactive" }}</dd>
           <dd class="nhsuk-summary-list__actions">
             <ul class="nhsuk-list">
+              <li><a routerLink="manage">Manage account</a></li>
               <li><a *ngIf="user.isActive" routerLink="{{ action.url }}">{{ action.label }}</a></li>
               <li><a routerLink="/admin/users/{{ user.id }}/delete">Delete user</a></li>
             </ul>

--- a/src/modules/feature-modules/admin/pages/users/user-manage.component.html
+++ b/src/modules/feature-modules/admin/pages/users/user-manage.component.html
@@ -1,0 +1,20 @@
+<theme-content-wrapper [status]="pageStatus">
+  <div *ngIf="isActive" class="nhsuk-grid-row nhsuk-u-margin-bottom-5">
+    <div class="nhsuk-grid-column-full">
+      <h2 class="nhsuk-heading-l">Lock account</h2>
+      <p>Accounts should only be locked in exceptional circumstances, for example if the user has breached the term of use.
+      You will be able to unlock the user by activating any of their specific roles</p>
+      <a routerLink="lock"> Lock account </a>
+    </div>
+  </div>
+
+  <!-- <app-account-mfa-list *ngIf="MFAInfo" [MFAInfo]="MFAInfo" /> -->
+
+  <div *ngIf="isInnovator" class="nhsuk-grid-row nhsuk-u-margin-bottom-5">
+    <div class="nhsuk-grid-column-full">
+      <h2 class="nhsuk-heading-l">Delete your account</h2>
+      <p>You will need to confirm your email address to delete your account.</p>
+      <a routerLink="delete"> Delete your account </a>
+    </div>
+  </div>
+</theme-content-wrapper>

--- a/src/modules/feature-modules/admin/pages/users/user-manage.component.html
+++ b/src/modules/feature-modules/admin/pages/users/user-manage.component.html
@@ -2,19 +2,30 @@
   <div *ngIf="isActive" class="nhsuk-grid-row nhsuk-u-margin-bottom-5">
     <div class="nhsuk-grid-column-full">
       <h2 class="nhsuk-heading-l">Lock account</h2>
-      <p>Accounts should only be locked in exceptional circumstances, for example if the user has breached the term of use.
-      You will be able to unlock the user by activating any of their specific roles</p>
-      <a routerLink="lock"> Lock account </a>
+      <p>Accounts should only be locked in exceptional circumstances, for example if the user has breached the term of use.</p>
+      <p>You will be able to unlock the user by activating any of their specific roles</p>
+      <ul class="nhsuk-list">
+        <li><a routerLink="lock"> Lock account </a></li>
+      </ul>
+      <ul>
+        
+      </ul>
+    </div>
+  </div>
+
+  <div *ngIf="isInnovator" class="nhsuk-grid-row nhsuk-u-margin-bottom-5">
+    <div class="nhsuk-grid-column-full">
+      <h2 class="nhsuk-heading-l">Delete account</h2>
+      <p>If you delete an account, all innovations will be archived and collaborators will lose access to them. All support
+      organisations the innovator has shared your data with, will be able to view an archived version of the innovations.</p>
+      <p>You can transfer ownership of the innovations before deleting the account and this request will be active for 30 days.</p>
+      <ul class="nhsuk-list">
+        <li><a href="javascript:void(0)"> See innovations list (TODO) </a></li>
+        <li><a routerLink="delete"> Delete account </a></li>
+      </ul>
     </div>
   </div>
 
   <!-- <app-account-mfa-list *ngIf="MFAInfo" [MFAInfo]="MFAInfo" /> -->
 
-  <div *ngIf="isInnovator" class="nhsuk-grid-row nhsuk-u-margin-bottom-5">
-    <div class="nhsuk-grid-column-full">
-      <h2 class="nhsuk-heading-l">Delete your account</h2>
-      <p>You will need to confirm your email address to delete your account.</p>
-      <a routerLink="delete"> Delete your account </a>
-    </div>
-  </div>
 </theme-content-wrapper>

--- a/src/modules/feature-modules/admin/pages/users/user-manage.component.ts
+++ b/src/modules/feature-modules/admin/pages/users/user-manage.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { CoreComponent } from '@app/base';
 
@@ -7,16 +7,15 @@ import { CoreComponent } from '@app/base';
   templateUrl: './user-manage.component.html'
 })
 export class PageUserManageComponent extends CoreComponent implements OnInit {
-  @Input() isInnovator = false;
-  @Input() isActive = false;
-
-  user: any = {}; // TODO
+  isActive: boolean;
+  isInnovator: boolean;
 
   constructor(private route: ActivatedRoute) {
     super();
     this.setPageTitle('Manage account');
-    this.user = this.route.snapshot.data.user;
-    console.log(this.user);
+    const user = this.route.snapshot.data.user;
+    this.isActive = user.isActive;
+    this.isInnovator = user.isInnovator;
   }
 
   ngOnInit(): void {

--- a/src/modules/feature-modules/admin/pages/users/user-manage.component.ts
+++ b/src/modules/feature-modules/admin/pages/users/user-manage.component.ts
@@ -1,0 +1,25 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { CoreComponent } from '@app/base';
+
+@Component({
+  selector: 'app-admin-pages-users-user-manage',
+  templateUrl: './user-manage.component.html'
+})
+export class PageUserManageComponent extends CoreComponent implements OnInit {
+  @Input() isInnovator = false;
+  @Input() isActive = false;
+
+  user: any = {}; // TODO
+
+  constructor(private route: ActivatedRoute) {
+    super();
+    this.setPageTitle('Manage account');
+    this.user = this.route.snapshot.data.user;
+    console.log(this.user);
+  }
+
+  ngOnInit(): void {
+    this.setPageStatus('READY');
+  }
+}

--- a/src/modules/feature-modules/admin/resolvers/service-user-data.resolver.ts
+++ b/src/modules/feature-modules/admin/resolvers/service-user-data.resolver.ts
@@ -3,6 +3,7 @@ import { ActivatedRouteSnapshot } from '@angular/router';
 import { Observable } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 
+import { UserRoleEnum } from '@app/base/enums';
 import { UserInfo } from '@modules/shared/dtos/users.dto';
 import { AdminUsersService } from '../services/users.service';
 
@@ -15,7 +16,13 @@ export class ServiceUserDataResolver {
   resolve(route: ActivatedRouteSnapshot): Observable<ServiceUserData> {
     return this.usersService.getUserInfo(route.params.userId).pipe(
       take(1),
-      map(r => ({ id: r.id, name: r.name, email: r.email }))
+      map(r => ({
+        id: r.id,
+        name: r.name,
+        email: r.email,
+        isActive: r.isActive,
+        isInnovator: r.roles.some(r => r.role === UserRoleEnum.INNOVATOR)
+      }))
     );
   }
 }


### PR DESCRIPTION
- add a manage account action instead of lock + delete
- change the delete account flow in admin portal

Closes: [AB#174319](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/174319)