### PR TITLE
Bugfix/ Fix scroll-to-top for announcement flow and link length validation

### DIFF
--- a/src/modules/feature-modules/admin/pages/announcements/announcement-newdit.component.ts
+++ b/src/modules/feature-modules/admin/pages/announcements/announcement-newdit.component.ts
@@ -197,7 +197,8 @@ export class PageAnnouncementNewditComponent extends CoreComponent implements On
         break;
       case 'next':
         this.wizard.nextStep();
-        this.scroller.scrollToPosition([0, 0]);
+        // scroll to top if we go to summary
+        this.wizard.isSummaryStep() && this.scroller.scrollToPosition([0, 0]);
         break;
       default: // Should NOT happen!
         break;

--- a/src/modules/shared/forms/validators/custom-validators.ts
+++ b/src/modules/shared/forms/validators/custom-validators.ts
@@ -347,15 +347,9 @@ export class CustomValidators {
       }
 
       if (firstControl?.value) {
-        if (firstControl.value.length > INPUT_LENGTH_LIMIT.xs) {
-          return { maxLength: true };
-        }
         if (!secondControl?.value) {
           secondControl?.setErrors({ required: secondField.message ? { message: secondField.message } : true });
         } else {
-          if (secondControl.value.length > INPUT_LENGTH_LIMIT.l) {
-            return { maxLength: true };
-          }
           secondControl?.setErrors(secondControlErrors);
         }
         return null;


### PR DESCRIPTION
- Scrolls to top on `nextstep()` only if it's summary page
- Removes unnecessary logic for length validation