### PR TITLE
bugfix/ Adds maxLength optional param to formatUrl validator

### DIFF
--- a/src/app/config/translations/en.ts
+++ b/src/app/config/translations/en.ts
@@ -1084,6 +1084,8 @@ export const locale = {
           invalid_hexadecimal_format: 'Invalid hexadecimal format',
           invalid_json_format: 'Invalid JSON format',
           invalid_url_format: 'The format of this URL is invalid. Add the full URL, including http:// or https://',
+          invalid_url_format_maxLength:
+            'The format of this URL is invalid. Add the full URL, including http:// or https://. The URL cannot exceed {{maxLength}} characters.',
           invalid_value: 'Invalid value',
           min: 'Value below the minimum allowed',
           min_hexadecimal: 'Value below the minimum allowed',

--- a/src/modules/feature-modules/admin/pages/announcements/announcement-newdit.config.ts
+++ b/src/modules/feature-modules/admin/pages/announcements/announcement-newdit.config.ts
@@ -159,7 +159,7 @@ export const ANNOUNCEMENT_NEW_QUESTIONS: WizardEngineModel = new WizardEngineMod
           id: 'linkUrl',
           dataType: 'text',
           label: stepsLabels.s3.p2.label,
-          validations: { urlFormat: true, maxLength: INPUT_LENGTH_LIMIT.l }
+          validations: { urlFormat: { maxLength: INPUT_LENGTH_LIMIT.l } }
         }
       ]
     }),

--- a/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.config.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.config.ts
@@ -5,6 +5,7 @@ import {
   WizardStepType,
   WizardSummaryType
 } from '@modules/shared/forms';
+import { INPUT_LENGTH_LIMIT } from '@modules/shared/forms/engine/config/form-engine.config';
 import { catalogOfficeLocation } from '@modules/stores/innovation/innovation-record/202304/catalog.types';
 import { countriesItems, locationItems } from '@modules/stores/innovation/innovation-record/202304/forms.config';
 
@@ -156,7 +157,10 @@ function runtimeRules(steps: WizardStepType[], currentValues: StepPayloadType, c
                 id: 'website',
                 dataType: 'text',
                 label: 'Website',
-                validations: { isRequired: [true, 'Website url is required'], maxLength: 100, urlFormat: true }
+                validations: {
+                  isRequired: [true, 'Website url is required'],
+                  urlFormat: { maxLength: INPUT_LENGTH_LIMIT.xxs }
+                }
               })
             },
             { value: 'NO', label: 'No' }

--- a/src/modules/shared/forms/engine/helpers/form-engine.helper.ts
+++ b/src/modules/shared/forms/engine/helpers/form-engine.helper.ts
@@ -273,7 +273,13 @@ export class FormEngineHelper {
       };
     }
     if (error.urlFormat) {
-      return { message: error.urlFormat.message || 'shared.forms_module.validations.invalid_url_format', params: {} };
+      return {
+        message:
+          error.urlFormat.message || error.urlFormat.maxLength
+            ? 'shared.forms_module.validations.invalid_url_format_maxLength'
+            : 'shared.forms_module.validations.invalid_url_format',
+        params: { maxLength: error.urlFormat.maxLength }
+      };
     }
 
     if (error.hexadecimalFormat) {
@@ -478,13 +484,7 @@ export class FormEngineHelper {
     }
 
     if (parameter.validations?.urlFormat) {
-      validation =
-        typeof parameter.validations.urlFormat === 'boolean'
-          ? [parameter.validations.urlFormat, null]
-          : parameter.validations.urlFormat;
-      if (validation[0]) {
-        validators.push(CustomValidators.urlFormatValidator(validation[1]));
-      }
+      validators.push(CustomValidators.urlFormatValidator(parameter.validations.urlFormat));
     }
 
     // Specific types field validations.

--- a/src/modules/shared/forms/engine/models/form-engine.models.ts
+++ b/src/modules/shared/forms/engine/models/form-engine.models.ts
@@ -61,7 +61,7 @@ export class FormEngineParameterModel {
     existsIn?: string[] | [string[], string];
     validEmail?: boolean | [boolean, string];
     postcodeFormat?: boolean | [boolean, string];
-    urlFormat?: boolean | [boolean, string];
+    urlFormat?: { message?: string; maxLength?: number };
     equalTo?: string | [string, string];
     requiredDateInput?: { message?: string };
     dateInputFormat?: { message?: string };

--- a/src/modules/shared/forms/validators/custom-validators.ts
+++ b/src/modules/shared/forms/validators/custom-validators.ts
@@ -142,11 +142,16 @@ export class CustomValidators {
     };
   }
 
-  static urlFormatValidator(message?: string | null): ValidatorFn {
+  static urlFormatValidator(data?: { message?: string | null; maxLength?: number }): ValidatorFn {
     return (control: AbstractControl): ValidationErrors | null => {
       if (!control.value) {
         return null;
       }
+
+      if (data?.maxLength && control.value.length > data.maxLength) {
+        return { urlFormat: data };
+      }
+
       const pattern = new RegExp(
         '^(https?:\\/\\/)' + // protocol (mandator)
           '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
@@ -156,11 +161,12 @@ export class CustomValidators {
           '(\\#[-a-z\\d_]*)?$', // fragment locator
         'i'
       );
+
       if (pattern.test(control.value)) {
         return null;
       }
 
-      return { urlFormat: message ? { message } : true };
+      return { urlFormat: data };
     };
   }
 

--- a/src/modules/stores/innovation/innovation-record/202304/section-1-1.config.ts
+++ b/src/modules/stores/innovation/innovation-record/202304/section-1-1.config.ts
@@ -191,7 +191,7 @@ function runtimeRules(steps: WizardStepType[], currentValues: StepPayloadType, c
                 id: 'website',
                 dataType: 'text',
                 label: 'Website',
-                validations: { isRequired: [true, 'Website url is required'], maxLength: 100, urlFormat: true }
+                validations: { isRequired: [true, 'Website url is required'], urlFormat: { maxLength: 100 } }
               })
             },
             { value: 'NO', label: 'No' }

--- a/src/modules/stores/innovation/innovation-record/202304/section-1-1.config.ts
+++ b/src/modules/stores/innovation/innovation-record/202304/section-1-1.config.ts
@@ -20,6 +20,7 @@ import {
   locationItems,
   mainPurposeItems
 } from './forms.config';
+import { INPUT_LENGTH_LIMIT } from '@modules/shared/forms/engine/config/form-engine.config';
 
 // Labels.
 const stepsLabels = {
@@ -191,7 +192,10 @@ function runtimeRules(steps: WizardStepType[], currentValues: StepPayloadType, c
                 id: 'website',
                 dataType: 'text',
                 label: 'Website',
-                validations: { isRequired: [true, 'Website url is required'], urlFormat: { maxLength: 100 } }
+                validations: {
+                  isRequired: [true, 'Website url is required'],
+                  urlFormat: { maxLength: INPUT_LENGTH_LIMIT.xxs }
+                }
               })
             },
             { value: 'NO', label: 'No' }


### PR DESCRIPTION
- Adds an optional `maxLength` parameter to `formatUrl` validator

Screenshot:
![image](https://github.com/user-attachments/assets/a47757bd-5309-42ad-b28e-57aa96ce5667)