### PR TITLE
Fix/ Update success message to display full name for black-orgs instead of acronym

### DIFF
--- a/src/modules/shared/pages/switch-context/switch-context.component.ts
+++ b/src/modules/shared/pages/switch-context/switch-context.component.ts
@@ -89,9 +89,7 @@ export class PageSwitchContextComponent extends CoreComponent {
       });
 
       const roleDescription = `${this.authenticationStore.getRoleDescription(role.type).toLowerCase()}${
-        role.organisationUnit
-          ? `, ${this.displayNameOrAcronym(role.organisationUnit.name, role.organisationUnit.acronym)}`
-          : ''
+        role.organisationUnit ? `, ${role.organisationUnit.name}` : ''
       }`;
       this.setRedirectAlertSuccess(`You are now logged in as ${roleDescription}`);
 


### PR DESCRIPTION
Fix: 
Update success message to display full name for black-orgs instead of acronym

screenshots:
![image](https://github.com/user-attachments/assets/1bb6c7d3-8c0c-4b07-b381-eff1cc2000b9)
![image](https://github.com/user-attachments/assets/692858ec-3b02-41ac-8e86-5de052d3d8a2)
