### PR TITLE
Bugfix/fixes for change support status to waiting

### DIFF
--- a/src/modules/feature-modules/accessor/pages/innovation/support/support-change-accessors.component.html
+++ b/src/modules/feature-modules/accessor/pages/innovation/support/support-change-accessors.component.html
@@ -15,6 +15,7 @@
             [label]="selectAccessorsStepLabel"
             [items]="formAccessorsList"
             [pageUniqueField]="false"
+            [disabledItems]="disabledCheckboxAccessors"
           ></theme-form-checkbox-array>
 
           <button class="nhsuk-button nhsuk-u-margin-top-3" (click)="onSubmitStep()">Continue</button>

--- a/src/modules/feature-modules/accessor/pages/innovation/support/support-change-accessors.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovation/support/support-change-accessors.component.ts
@@ -33,6 +33,8 @@ export class InnovationChangeAccessorsComponent extends CoreComponent implements
 
   innovationSupportStatus: InnovationSupportStatusEnum | undefined;
 
+  disabledCheckboxAccessors: string[] = [];
+
   form = new FormGroup(
     {
       accessors: new FormArray<FormControl<string>>([], { updateOn: 'change' }),
@@ -89,6 +91,13 @@ export class InnovationChangeAccessorsComponent extends CoreComponent implements
           innovationSupportInfo.engagingAccessors.forEach(accessor => {
             (this.form.get('accessors') as FormArray).push(new FormControl<string>(accessor.id));
           });
+        }
+
+        if (this.innovationSupportStatus === InnovationSupportStatusEnum.WAITING) {
+          // add this user by default, and disable input
+          const userId = this.stores.authentication.getUserId();
+          (this.form.get('accessors') as FormArray).push(new FormControl<string>(userId));
+          this.disabledCheckboxAccessors = [userId];
         }
 
         this.setPageStatus('READY');


### PR DESCRIPTION
Description: 
- Adds current QA user as default and locked, on an innovation's `change accessor` flow
- Fixes previously existing problem on `update support` flow with titles when clicking on `go back` link
- Fixes not showing summary list of selected QA's on last step, when changing support to WAITING, when the organisation has only 1 QA.

Related US: 
[AB#175660](https://dev.azure.com/NHSiDev/InnovatorService/_workitems/edit/175660)