### PR TITLE
Password reset date should now always be updated

### DIFF
--- a/src/modules/feature-modules/accessor/pages/dashboard/dashboard.component.ts
+++ b/src/modules/feature-modules/accessor/pages/dashboard/dashboard.component.ts
@@ -55,7 +55,7 @@ export class DashboardComponent extends CoreComponent implements OnInit {
       const newState = history.state;
       delete newState.alert;
       history.replaceState(newState, '');
-      this.stores.authentication.updateUserPasswordResetDate();
+      this.stores.authentication.userPasswordSuccessfullyUpdated();
     }
 
     const qp: { statistics: UserStatisticsTypeEnum[] } = {

--- a/src/modules/feature-modules/admin/pages/dashboard/dashboard.component.ts
+++ b/src/modules/feature-modules/admin/pages/dashboard/dashboard.component.ts
@@ -18,7 +18,7 @@ export class PageDashboardComponent extends CoreComponent implements OnInit {
       const newState = history.state;
       delete newState.alert;
       history.replaceState(newState, '');
-      this.stores.authentication.updateUserPasswordResetDate();
+      this.stores.authentication.userPasswordSuccessfullyUpdated();
     }
 
     this.setPageStatus('READY');

--- a/src/modules/feature-modules/assessment/pages/dashboard/dashboard.component.ts
+++ b/src/modules/feature-modules/assessment/pages/dashboard/dashboard.component.ts
@@ -57,7 +57,7 @@ export class DashboardComponent extends CoreComponent implements OnInit {
       const newState = history.state;
       delete newState.alert;
       history.replaceState(newState, '');
-      this.stores.authentication.updateUserPasswordResetDate();
+      this.stores.authentication.userPasswordSuccessfullyUpdated();
     }
 
     const qp: { statistics: UserStatisticsTypeEnum[] } = {

--- a/src/modules/feature-modules/innovator/pages/dashboard/dashboard.component.ts
+++ b/src/modules/feature-modules/innovator/pages/dashboard/dashboard.component.ts
@@ -82,7 +82,7 @@ export class PageDashboardComponent extends CoreComponent implements OnInit {
       const newState = history.state;
       delete newState.alert;
       history.replaceState(newState, '');
-      this.stores.authentication.updateUserPasswordResetDate();
+      this.stores.authentication.userPasswordSuccessfullyUpdated();
     }
 
     forkJoin([

--- a/src/modules/shared/pages/account/manage-account-info/manage-account-info.component.ts
+++ b/src/modules/shared/pages/account/manage-account-info/manage-account-info.component.ts
@@ -25,9 +25,23 @@ export class PageSharedAccountManageAccountInfoComponent extends CoreComponent i
     this.setPageTitle('Manage account');
 
     const user = this.stores.authentication.getUserInfo();
+
     this.user = {
       passwordResetAt: user.passwordResetAt
     };
+
+    if (user.passwordChangeSinceLastSignIn) {
+      this.authenticationService.getUserInfo(true).subscribe({
+        next: updatedUser => {
+          this.user = {
+            passwordResetAt: updatedUser.passwordResetAt
+          };
+        },
+        error: error => {
+          console.error('Failed to fetch user info:', error);
+        }
+      });
+    }
   }
 
   ngOnInit(): void {

--- a/src/modules/stores/authentication/authentication.models.ts
+++ b/src/modules/stores/authentication/authentication.models.ts
@@ -30,6 +30,7 @@ export class AuthenticationModel {
     hasInnovationCollaborations: boolean;
     hasLoginAnnouncements: { [k: string]: boolean };
     passwordResetAt: null | DateISOType;
+    passwordChangeSinceLastSignIn?: boolean;
     firstTimeSignInAt: null | DateISOType;
     organisations: {
       id: string;

--- a/src/modules/stores/authentication/authentication.store.ts
+++ b/src/modules/stores/authentication/authentication.store.ts
@@ -161,17 +161,10 @@ export class AuthenticationStore extends Store<AuthenticationModel> {
     );
   }
 
-  updateUserPasswordResetDate() {
-    this.authenticationService.getUserInfo(true).subscribe({
-      next: user => {
-        if (this.state.user) {
-          this.state.user.passwordResetAt = user.passwordResetAt;
-        }
-      },
-      error: error => {
-        console.error('Failed to fetch user info:', error);
-      }
-    });
+  userPasswordSuccessfullyUpdated() {
+    if (this.state.user) {
+      this.state.user.passwordChangeSinceLastSignIn = true;
+    }
   }
 
   updateUserInfo$(body: UpdateUserInfoDTO): Observable<{ id: string }> {


### PR DESCRIPTION
[AB#177025](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/177025)

The previous version had a sync problem. 
Two requests were made to the /me endpoint, one was a regular one and the other forced the cache refresh. The problem was that sometimes the the regular one finished after the second one and would update the FE store with the previous (wrong) reset password date.

This should be fixed now, since it should be retrieving this date synchronously, but only when the password was changed during the current session to avoid to many requests.