### PR TITLE
fix: transfer ownership for an innovation in store should clear

### DIFF
--- a/src/modules/feature-modules/innovator/pages/dashboard/dashboard.component.html
+++ b/src/modules/feature-modules/innovator/pages/dashboard/dashboard.component.html
@@ -1,4 +1,5 @@
-<theme-content-wrapper [status]="pageStatus()">  <ng-container *ngFor="let announcement of announcements">
+<theme-content-wrapper [status]="pageStatus()">
+  <ng-container *ngFor="let announcement of announcements">
     <theme-announcements-card
       [announcementCardData]="{ id: announcement.id, title: announcement.title, params: announcement.params, innovations: announcement.innovations }"
       (clearedAnnouncement)="onClearAnnouncement($event)"
@@ -25,8 +26,12 @@
             <div class="nhsuk-card__content">
               <h2 class="nhsuk-card__heading nhsuk-heading-m">You have an innovation ownership transfer request</h2>
               <p class="nhsuk-card__description">You have been requested to take ownership of {{ item.innovation.name }} by its owner.</p>
-              <button class="nhsuk-button nhsuk-u-margin-right-3 nhsuk-u-margin-bottom-0" (click)="onSubmitTransferResponse(item.id, true)">Accept ownership</button>
-              <button class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-0" (click)="onSubmitTransferResponse(item.id, false)">Reject request</button>
+              <button class="nhsuk-button nhsuk-u-margin-right-3 nhsuk-u-margin-bottom-0" (click)="onSubmitTransferResponse(item.id, item.innovation.id, true)">
+                Accept ownership
+              </button>
+              <button class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-0" (click)="onSubmitTransferResponse(item.id, item.innovation.id, false)">
+                Reject request
+              </button>
             </div>
           </div>
         </li>


### PR DESCRIPTION
**Description:**
- Force innovation store refresh when a transfer is accepted for an innovation in store.
- Updated method to remove the eslint warning of unused variable
- Reduced an unnecessary call to transfers endpoint