### PR TITLE
task: add constraint to not pool when tab is not active

### DIFF
--- a/src/modules/core/guards/authentication-redirection.guard.ts
+++ b/src/modules/core/guards/authentication-redirection.guard.ts
@@ -64,7 +64,6 @@ export class AuthenticationRedirectionGuard {
     }
 
     if (pathSegment === this.ctx.user.userUrlBasePath()) {
-      this.ctx.notifications.fetchUnread$.next();
       return true;
     } else {
       this.router.navigateByUrl(this.ctx.user.userUrlBasePath());


### PR DESCRIPTION
**Description:**
- Now the notifications counter isn't pooling while the tab is inactive.
- Now the notifications counter fetch is fetched when the user store state is loaded.

**Related tickets:**
- Closes [AB#178329](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/178329)
- US: [AB#177490](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/177490)