### PR TITLE
bugfix/168761- Changes the use of 'state' for 'queryParams', adds missing logic for AC04

### DIFF
--- a/src/modules/feature-modules/accessor/pages/innovation/custom-notifications/custom-notifications-entrypoint.component.html
+++ b/src/modules/feature-modules/accessor/pages/innovation/custom-notifications/custom-notifications-entrypoint.component.html
@@ -4,7 +4,9 @@
     @for (item of links; track $index) {
       <li>
         <p>
-          <a href="javascript:void(0)" (click)="onNotify(item.action)">{{ item.label }}</a>
+          <a routerLink="/{{ this.ctx.user.userUrlBasePath() }}/innovations/{{ this.innovationId }}/custom-notifications/new" [queryParams]="getItemParams(item)">
+            {{ item.label }}</a
+          >
         </p>
       </li>
     }

--- a/src/modules/feature-modules/accessor/pages/innovation/custom-notifications/custom-notifications-entrypoint.component.ts
+++ b/src/modules/feature-modules/accessor/pages/innovation/custom-notifications/custom-notifications-entrypoint.component.ts
@@ -3,14 +3,18 @@ import { ActivatedRoute } from '@angular/router';
 import { CoreComponent } from '@app/base';
 import { NotificationEnum } from '@modules/feature-modules/accessor/services/accessor.service';
 
-export type CustomNotificationEntrypointComponentLinksType = { label: string; action: NotificationEnum }[];
+export type CustomNotificationEntrypointComponentLinksType = {
+  label: string;
+  action: NotificationEnum;
+  section?: string;
+};
 
 @Component({
   selector: 'theme-custom-notifications-entrypoint-component',
   templateUrl: './custom-notifications-entrypoint.component.html'
 })
 export class CustomNotificationsEntrypointComponent extends CoreComponent {
-  @Input() links: CustomNotificationEntrypointComponentLinksType = [];
+  @Input() links: CustomNotificationEntrypointComponentLinksType[] = [];
   innovationId: string;
 
   constructor(private activatedRoute: ActivatedRoute) {
@@ -21,5 +25,12 @@ export class CustomNotificationsEntrypointComponent extends CoreComponent {
   onNotify(customNotificationAction: NotificationEnum) {
     const url = `/${this.ctx.user.userUrlBasePath()}/innovations/${this.innovationId}/custom-notifications/new`;
     this.router.navigateByUrl(url, { state: { customNotificationAction } });
+  }
+
+  getItemParams(item: CustomNotificationEntrypointComponentLinksType): { action: NotificationEnum; section?: string } {
+    return {
+      action: item.action,
+      ...(item.section && { section: item.section })
+    };
   }
 }

--- a/src/modules/shared/pages/innovation/documents/documents-list.component.ts
+++ b/src/modules/shared/pages/innovation/documents/documents-list.component.ts
@@ -55,7 +55,7 @@ export class PageInnovationDocumentsListComponent extends CoreComponent implemen
   uploadedByUnitChips: ChipFilterInputType = [];
   selectedUploadedByUnitChips: string[] = [];
 
-  customNotificationLinks: CustomNotificationEntrypointComponentLinksType = [];
+  customNotificationLinks: CustomNotificationEntrypointComponentLinksType[] = [];
 
   constructor(
     private innovationDocumentsService: InnovationDocumentsService,

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.ts
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.ts
@@ -48,7 +48,7 @@ export class PageInnovationRecordComponent extends CoreComponent implements OnIn
 
   allSectionsSubmitted = false;
 
-  customNotificationLinks: CustomNotificationEntrypointComponentLinksType = [];
+  customNotificationLinks: CustomNotificationEntrypointComponentLinksType[] = [];
 
   constructor(
     private activatedRoute: ActivatedRoute,

--- a/src/modules/shared/pages/innovation/sections/section-info-all.component.ts
+++ b/src/modules/shared/pages/innovation/sections/section-info-all.component.ts
@@ -68,7 +68,7 @@ export class PageInnovationAllSectionsInfoComponent extends CoreComponent implem
     }
   > = {};
 
-  customNotificationLinks: CustomNotificationEntrypointComponentLinksType = [];
+  customNotificationLinks: CustomNotificationEntrypointComponentLinksType[] = [];
 
   constructor(
     private activatedRoute: ActivatedRoute,

--- a/src/modules/shared/pages/innovation/sections/section-info.component.ts
+++ b/src/modules/shared/pages/innovation/sections/section-info.component.ts
@@ -65,7 +65,7 @@ export class PageInnovationSectionInfoComponent extends CoreComponent implements
 
   search?: string;
 
-  customNotificationLinks: CustomNotificationEntrypointComponentLinksType = [];
+  customNotificationLinks: CustomNotificationEntrypointComponentLinksType[] = [];
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -221,7 +221,8 @@ export class PageInnovationSectionInfoComponent extends CoreComponent implements
       this.customNotificationLinks = [
         {
           label: 'Notify me when this section of the innovation record is updated',
-          action: NotificationEnum.INNOVATION_RECORD_UPDATED
+          action: NotificationEnum.INNOVATION_RECORD_UPDATED,
+          section: this.sectionId
         }
       ];
 

--- a/src/modules/shared/pages/innovation/support/support-summary-list.component.ts
+++ b/src/modules/shared/pages/innovation/support/support-summary-list.component.ts
@@ -57,7 +57,7 @@ export class PageInnovationSupportSummaryListComponent extends CoreComponent imp
     { id: 'SUGGESTED', title: 'Other suggested support organisations', unitsList: [] }
   ];
 
-  customNotificationLinks: CustomNotificationEntrypointComponentLinksType = [];
+  customNotificationLinks: CustomNotificationEntrypointComponentLinksType[] = [];
 
   constructor(
     private activatedRoute: ActivatedRoute,


### PR DESCRIPTION
Fixes:
- Refactor to pass data using `queryparams` instead of `state`, as we need the links to open in new tab, and state doesn't persist.
- Added logic to pre-fill section and skip that step, when creating a custom notification within a section on the IR. (AC04)

US:
[AB#168761](https://dev.azure.com/NHSiDev/InnovatorService/_workitems/edit/168761)