### PR TITLE
Change innovation record based on innovation status

### DIFF
--- a/src/modules/shared/pages/innovation/record/innovation-record-progress.component.html
+++ b/src/modules/shared/pages/innovation/record/innovation-record-progress.component.html
@@ -1,0 +1,19 @@
+<p class="d-flex nhsuk-u-margin-0">
+  <theme-svg-icon type="success"></theme-svg-icon>
+  <span class="nhsuk-u-margin-right-2"></span>
+  {{ sectionsComplete() }} of {{ sectionsTotal() }} {{ "dictionary.section" | pluralTranslate: sectionsTotal() | translate }} completed
+</p>
+@if (sectionsDraft() > 0) {
+  <p class="d-flex nhsuk-u-margin-0">
+    <theme-svg-icon type="edit"></theme-svg-icon>
+    <span class="nhsuk-u-margin-right-2"></span>
+    {{ sectionsDraft() }} {{ "dictionary.section" | pluralTranslate: sectionsDraft() | translate }} in draft
+  </p>
+}
+@if (sectionsNotStarted() > 0) {
+  <p class="d-flex">
+    <theme-svg-icon type="not-started" customColor="grey"></theme-svg-icon>
+    <span class="nhsuk-u-margin-right-2"></span>
+    {{ sectionsNotStarted() }} {{ "dictionary.section" | pluralTranslate: sectionsNotStarted() | translate }} not started
+  </p>
+}

--- a/src/modules/shared/pages/innovation/record/innovation-record-progress.component.html
+++ b/src/modules/shared/pages/innovation/record/innovation-record-progress.component.html
@@ -1,19 +1,30 @@
-<p class="d-flex nhsuk-u-margin-0">
-  <theme-svg-icon type="success"></theme-svg-icon>
-  <span class="nhsuk-u-margin-right-2"></span>
-  {{ sectionsComplete() }} of {{ sectionsTotal() }} {{ "dictionary.section" | pluralTranslate: sectionsTotal() | translate }} completed
-</p>
-@if (sectionsDraft() > 0) {
+@if (showDetailed().length) {
+  <ul class="nhsuk-list nhsuk-list--bullet">
+    @for (section of showDetailed(); track section.id) {
+      <li>
+        {{ section.statusLabel }} section
+        <a routerLink="sections/{{ section.id }}/"> {{ section.fullTitle }} </a>
+      </li>
+    }
+  </ul>
+} @else {
   <p class="d-flex nhsuk-u-margin-0">
-    <theme-svg-icon type="edit"></theme-svg-icon>
+    <theme-svg-icon type="success" />
     <span class="nhsuk-u-margin-right-2"></span>
-    {{ sectionsDraft() }} {{ "dictionary.section" | pluralTranslate: sectionsDraft() | translate }} in draft
+    {{ sectionsComplete() }} of {{ sectionsTotal() }} {{ "dictionary.section" | pluralTranslate: sectionsTotal() | translate }} completed
   </p>
-}
-@if (sectionsNotStarted() > 0) {
-  <p class="d-flex">
-    <theme-svg-icon type="not-started" customColor="grey"></theme-svg-icon>
-    <span class="nhsuk-u-margin-right-2"></span>
-    {{ sectionsNotStarted() }} {{ "dictionary.section" | pluralTranslate: sectionsNotStarted() | translate }} not started
-  </p>
+  @if (sectionsDraft() > 0) {
+    <p class="d-flex nhsuk-u-margin-0">
+      <theme-svg-icon type="edit" />
+      <span class="nhsuk-u-margin-right-2"></span>
+      {{ sectionsDraft() }} {{ "dictionary.section" | pluralTranslate: sectionsDraft() | translate }} in draft
+    </p>
+  }
+  @if (sectionsNotStarted() > 0) {
+    <p class="d-flex">
+      <theme-svg-icon type="not-started" customColor="grey" />
+      <span class="nhsuk-u-margin-right-2"></span>
+      {{ sectionsNotStarted() }} {{ "dictionary.section" | pluralTranslate: sectionsNotStarted() | translate }} not started
+    </p>
+  }
 }

--- a/src/modules/shared/pages/innovation/record/innovation-record-progress.component.ts
+++ b/src/modules/shared/pages/innovation/record/innovation-record-progress.component.ts
@@ -1,5 +1,8 @@
-import { Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { CoreComponent } from '@app/base';
 import { PluralTranslatePipe } from '@modules/shared/pipes/plural-translate.pipe';
+import { InnovationSectionStatusEnum } from '@modules/stores';
 import { SectionsSummaryModel } from '@modules/stores/ctx/innovation/innovation.models';
 import { ThemeModule } from '@modules/theme/theme.module';
 import { TranslateModule } from '@ngx-translate/core';
@@ -7,16 +10,33 @@ import { TranslateModule } from '@ngx-translate/core';
 @Component({
   selector: 'shared-innovation-record-progress',
   templateUrl: './innovation-record-progress.component.html',
-  imports: [ThemeModule, PluralTranslatePipe, TranslateModule],
+  imports: [ThemeModule, PluralTranslatePipe, TranslateModule, RouterLink],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   styles: [':host { display: block; }'] // allow host element to be styled
 })
-export class InnovationRecordProgressComponent {
+export class InnovationRecordProgressComponent extends CoreComponent {
   sections = input.required<SectionsSummaryModel>();
+  firstSubmission = input(false);
 
   flatSections = computed(() => this.sections().flatMap(s => s.sections));
   sectionsComplete = computed(() => this.flatSections().filter(s => s.status === 'SUBMITTED').length);
   sectionsDraft = computed(() => this.flatSections().filter(s => s.status === 'DRAFT').length);
   sectionsTotal = computed(() => this.flatSections().length);
   sectionsNotStarted = computed(() => this.flatSections().filter(s => s.status === 'NOT_STARTED').length);
+
+  showDetailed = computed(() =>
+    this.firstSubmission() && this.sectionsDraft() + this.sectionsNotStarted() < 4
+      ? this.flatSections()
+          .filter(s => s.status !== 'SUBMITTED')
+          .map(s => {
+            const identifier = this.ctx.schema.getIrSchemaSectionIdentificationV3(s.id);
+            return {
+              ...s,
+              statusLabel: s.status === InnovationSectionStatusEnum.NOT_STARTED ? 'Start' : 'Complete',
+              fullTitle: `${identifier?.group.number}.${identifier?.section.number} ${s.title}`
+            };
+          })
+      : []
+  );
 }

--- a/src/modules/shared/pages/innovation/record/innovation-record-progress.component.ts
+++ b/src/modules/shared/pages/innovation/record/innovation-record-progress.component.ts
@@ -1,39 +1,22 @@
-import { Component, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { PluralTranslatePipe } from '@modules/shared/pipes/plural-translate.pipe';
+import { SectionsSummaryModel } from '@modules/stores/ctx/innovation/innovation.models';
 import { ThemeModule } from '@modules/theme/theme.module';
 import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
   selector: 'shared-innovation-record-progress',
-  template: `
-    <p class="d-flex nhsuk-u-margin-0">
-      <theme-svg-icon type="success"></theme-svg-icon>
-      <span class="nhsuk-u-margin-right-2"></span>
-      {{ sectionsComplete() }} of {{ sectionsTotal() }}
-      {{ 'dictionary.section' | pluralTranslate: sectionsTotal() | translate }} completed
-    </p>
-    @if (sectionsDraft() > 0) {
-      <p class="d-flex nhsuk-u-margin-0">
-        <theme-svg-icon type="edit"></theme-svg-icon>
-        <span class="nhsuk-u-margin-right-2"></span>
-        {{ sectionsDraft() }} {{ 'dictionary.section' | pluralTranslate: sectionsDraft() | translate }} in draft
-      </p>
-    }
-    @if (sectionsNotStarted() > 0) {
-      <p class="d-flex">
-        <theme-svg-icon type="not-started" customColor="grey"></theme-svg-icon>
-        <span class="nhsuk-u-margin-right-2"></span>
-        {{ sectionsNotStarted() }} {{ 'dictionary.section' | pluralTranslate: sectionsNotStarted() | translate }} not
-        started
-      </p>
-    }
-  `,
+  templateUrl: './innovation-record-progress.component.html',
   imports: [ThemeModule, PluralTranslatePipe, TranslateModule],
-  standalone: true
+  standalone: true,
+  styles: [':host { display: block; }'] // allow host element to be styled
 })
 export class InnovationRecordProgressComponent {
-  sectionsComplete = input.required<number>();
-  sectionsDraft = input.required<number>();
-  sectionsTotal = input.required<number>();
-  sectionsNotStarted = input.required<number>();
+  sections = input.required<SectionsSummaryModel>();
+
+  flatSections = computed(() => this.sections().flatMap(s => s.sections));
+  sectionsComplete = computed(() => this.flatSections().filter(s => s.status === 'SUBMITTED').length);
+  sectionsDraft = computed(() => this.flatSections().filter(s => s.status === 'DRAFT').length);
+  sectionsTotal = computed(() => this.flatSections().length);
+  sectionsNotStarted = computed(() => this.flatSections().filter(s => s.status === 'NOT_STARTED').length);
 }

--- a/src/modules/shared/pages/innovation/record/innovation-record-progress.component.ts
+++ b/src/modules/shared/pages/innovation/record/innovation-record-progress.component.ts
@@ -1,0 +1,39 @@
+import { Component, input } from '@angular/core';
+import { PluralTranslatePipe } from '@modules/shared/pipes/plural-translate.pipe';
+import { ThemeModule } from '@modules/theme/theme.module';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'shared-innovation-record-progress',
+  template: `
+    <p class="d-flex nhsuk-u-margin-0">
+      <theme-svg-icon type="success"></theme-svg-icon>
+      <span class="nhsuk-u-margin-right-2"></span>
+      {{ sectionsComplete() }} of {{ sectionsTotal() }}
+      {{ 'dictionary.section' | pluralTranslate: sectionsTotal() | translate }} completed
+    </p>
+    @if (sectionsDraft() > 0) {
+      <p class="d-flex nhsuk-u-margin-0">
+        <theme-svg-icon type="edit"></theme-svg-icon>
+        <span class="nhsuk-u-margin-right-2"></span>
+        {{ sectionsDraft() }} {{ 'dictionary.section' | pluralTranslate: sectionsDraft() | translate }} in draft
+      </p>
+    }
+    @if (sectionsNotStarted() > 0) {
+      <p class="d-flex">
+        <theme-svg-icon type="not-started" customColor="grey"></theme-svg-icon>
+        <span class="nhsuk-u-margin-right-2"></span>
+        {{ sectionsNotStarted() }} {{ 'dictionary.section' | pluralTranslate: sectionsNotStarted() | translate }} not
+        started
+      </p>
+    }
+  `,
+  imports: [ThemeModule, PluralTranslatePipe, TranslateModule],
+  standalone: true
+})
+export class InnovationRecordProgressComponent {
+  sectionsComplete = input.required<number>();
+  sectionsDraft = input.required<number>();
+  sectionsTotal = input.required<number>();
+  sectionsNotStarted = input.required<number>();
+}

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.html
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.html
@@ -28,17 +28,35 @@
 
     <div class="nhsuk-grid-column-full">
       @if (showSubmit) {
-        <div class="nhsuk-card">
-          <div class="nhsuk-card__content">
-            <h2 class="nhsuk-card__heading nhsuk-heading-m">
-              {{ sections.total }} sections to complete until you can submit for needs {{ isReassessment ? "reassessment" : "assessment" }}
-            </h2>
-            <shared-innovation-record-progress [sections]="innovationSections" />
-            <button type="submit" [routerLink]="submitUrl" [disabled]="!allSectionsSubmitted" class="nhsuk-button nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-2">
-              Submit record for needs {{ isReassessment ? "reassessment" : "assessment" }}
-            </button>
+        @if (allSectionsSubmitted) {
+          <!-- This is very similar to the content on the innovation submission ready component -->
+          <div class="nhsuk-card">
+            <div class="nhsuk-card__content nhsuk-u-padding-4">
+              <h3 class="nhsuk-card__heading nhsuk-u-margin-bottom-4">Innovation record ready to submit</h3>
+              <p>When you submit your innovation record the needs assessment team will:</p>
+              <ul class="nhsuk-list nhsuk-list--bullet">
+                <li>review your innovation record to assess your needs.</li>
+                <li>notify the appropriate support organisations.</li>
+                <li>contact you with next steps.</li>
+              </ul>
+              <p>This process usually takes 1 week.</p>
+              <p>The needs assessment team will get in touch with you if they need any additional information.</p>
+              <button type="submit" class="nhsuk-button" routerLink="support">Submit record for needs assessment</button>
+            </div>
           </div>
-        </div>
+        } @else {
+          <div class="nhsuk-card">
+            <div class="nhsuk-card__content">
+              <h2 class="nhsuk-card__heading nhsuk-heading-m">
+                {{ sections.incompleteSections }} sections to complete until you can submit for needs {{ isReassessment ? "reassessment" : "assessment" }}
+              </h2>
+              <shared-innovation-record-progress [sections]="innovationSections" [firstSubmission]="!isReassessment" />
+              <button type="submit" [routerLink]="submitUrl" [disabled]="!allSectionsSubmitted" class="nhsuk-button nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-2">
+                Submit record for needs {{ isReassessment ? "reassessment" : "assessment" }}
+              </button>
+            </div>
+          </div>
+        }
       } @else {
         <shared-innovation-record-progress [sections]="innovationSections" class="nhsuk-u-margin-bottom-6" />
       }

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.html
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.html
@@ -33,24 +33,14 @@
             <h2 class="nhsuk-card__heading nhsuk-heading-m">
               {{ sections.total }} sections to complete until you can submit for needs {{ isReassessment ? "reassessment" : "assessment" }}
             </h2>
-            <shared-innovation-record-progress
-              [sectionsComplete]="sections.submitted"
-              [sectionsDraft]="sections.draft"
-              [sectionsNotStarted]="sections.notStarted"
-              [sectionsTotal]="sections.total"
-            ></shared-innovation-record-progress>
+            <shared-innovation-record-progress [sections]="innovationSections" />
             <button type="submit" [routerLink]="submitUrl" [disabled]="!allSectionsSubmitted" class="nhsuk-button nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-2">
               Submit record for needs {{ isReassessment ? "reassessment" : "assessment" }}
             </button>
           </div>
         </div>
       } @else {
-        <shared-innovation-record-progress
-          [sectionsComplete]="sections.submitted"
-          [sectionsDraft]="sections.draft"
-          [sectionsNotStarted]="sections.notStarted"
-          [sectionsTotal]="sections.total"
-        ></shared-innovation-record-progress>
+        <shared-innovation-record-progress [sections]="innovationSections" class="nhsuk-u-margin-bottom-6" />
       }
 
       @if (ctx.user.isInnovator() && sections.withOpenTasksCount > 0) {

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.html
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.html
@@ -9,52 +9,52 @@
   <!--TODO: Banner for owner with account delete (new US)-->
 
   <div class="nhsuk-grid-row">
-    <ng-container *ngIf="ctx.user.isInnovator()">
-      <ng-container *ngIf="sections.submitted > 0; else firstTimeBanner">
-        <div class="nhsuk-grid-column-full">
-          <ng-container *ngIf="isInnovationInCreatedStatus">
-            <p>You'll need to complete all 11 sections of your innovation record before you can submit your record for a needs assessment.</p>
-            <p>
-              If you are unable to answer a question yet, you can still mark the section as complete. This will help us match you with organisations that can support you in these
-              areas.
-            </p>
-          </ng-container>
-          <ng-container *ngIf="isInnovationInArchivedStatus && isLoggedUserOwner; else innovationSharedText">
-            <p>You archived this innovation on {{ innovation.statusUpdatedAt | date: ("app.date_formats.long_date" | translate) }}. All support has ended.</p>
-          </ng-container>
-          <ng-template #innovationSharedText>
-            <p>
-              This is a live document for you to update as you develop your innovation. You can make changes to your innovation record even after submitting it for a needs
-              assessment.
-            </p>
-          </ng-template>
-        </div>
-      </ng-container>
-    </ng-container>
+    <div class="nhsuk-grid-column-full">
+      @if (ctx.user.isInnovator()) {
+        @if (isInnovationInCreatedStatus) {
+          <p>Your innovation record helps us match you with organisations that can support you in the areas you need.</p>
+        }
+
+        @if (isInnovationInArchivedStatus && isLoggedUserOwner) {
+          <p>You archived this innovation on {{ innovation.statusUpdatedAt | date: ("app.date_formats.long_date" | translate) }}. All support has ended.</p>
+        } @else {
+          <p>
+            This is a live document for you to update as you develop your innovation. You can make changes to your innovation record at any time, even after submitting it for a
+            needs assessment.
+          </p>
+        }
+      }
+    </div>
 
     <div class="nhsuk-grid-column-full">
-      <ul *ngIf="isInnovationInCreatedStatus" class="progressbar progressbar-justified nhsuk-u-padding-bottom-2">
-        <li *ngFor="let item of sections.progressBar" class="progressbar-item" [ngClass]="item.substring(2)"></li>
-      </ul>
+      @if (showSubmit) {
+        <div class="nhsuk-card">
+          <div class="nhsuk-card__content">
+            <h2 class="nhsuk-card__heading nhsuk-heading-m">
+              {{ sections.total }} sections to complete until you can submit for needs {{ isReassessment ? "reassessment" : "assessment" }}
+            </h2>
+            <shared-innovation-record-progress
+              [sectionsComplete]="sections.submitted"
+              [sectionsDraft]="sections.draft"
+              [sectionsNotStarted]="sections.notStarted"
+              [sectionsTotal]="sections.total"
+            ></shared-innovation-record-progress>
+            <button type="submit" [routerLink]="submitUrl" [disabled]="!allSectionsSubmitted" class="nhsuk-button nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-2">
+              Submit record for needs {{ isReassessment ? "reassessment" : "assessment" }}
+            </button>
+          </div>
+        </div>
+      } @else {
+        <shared-innovation-record-progress
+          [sectionsComplete]="sections.submitted"
+          [sectionsDraft]="sections.draft"
+          [sectionsNotStarted]="sections.notStarted"
+          [sectionsTotal]="sections.total"
+        ></shared-innovation-record-progress>
+      }
 
-      <p class="d-flex nhsuk-u-margin-0">
-        <theme-svg-icon type="success"></theme-svg-icon>
-        <span class="nhsuk-u-margin-right-2"></span>
-        {{ sections.submitted }} of {{ sections.progressBar.length }} {{ "dictionary.section" | pluralTranslate: sections.progressBar.length | translate }} completed
-      </p>
-      <p *ngIf="sections.draft > 0" class="d-flex nhsuk-u-margin-0">
-        <theme-svg-icon type="edit"></theme-svg-icon>
-        <span class="nhsuk-u-margin-right-2"></span>
-        {{ sections.draft }} {{ "dictionary.section" | pluralTranslate: sections.draft | translate }} in draft
-      </p>
-      <p *ngIf="sections.notStarted > 0" class="d-flex">
-        <theme-svg-icon type="error" customColor="grey"></theme-svg-icon>
-        <span class="nhsuk-u-margin-right-2"></span>
-        {{ sections.notStarted }} {{ "dictionary.section" | pluralTranslate: sections.notStarted | translate }} not started
-      </p>
-
-      <ng-container *ngIf="ctx.user.isInnovator()">
-        <div *ngIf="sections.withOpenTasksCount > 0" class="nhsuk-inset-text nhsuk-u-margin-top-3">
+      @if (ctx.user.isInnovator() && sections.withOpenTasksCount > 0) {
+        <div class="nhsuk-inset-text nhsuk-u-margin-top-3">
           <span class="nhsuk-u-visually-hidden">Information: </span>
           <p>
             {{ sections.withOpenTasksCount }} {{ "dictionary.section" | pluralTranslate: sections.withOpenTasksCount | translate }} with
@@ -62,26 +62,9 @@
             <a class="nhsuk-link nhsuk-link--no-visited-state" routerLink="/innovator/innovations/{{ innovationId }}/tasks">Go to tasks.</a>
           </p>
         </div>
+      }
 
-        <button
-          *ngIf="isInnovationInCreatedStatus || (isArchiveBeforeShare && isLoggedUserOwner)"
-          routerLink="/innovator/innovations/{{ innovationId }}/record/support"
-          [disabled]="!allSectionsSubmitted"
-          class="nhsuk-button nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-6"
-        >
-          Submit record for needs assessment
-        </button>
-        <button
-          *ngIf="isInnovationInArchivedStatus && !isArchiveBeforeShare && isLoggedUserOwner"
-          routerLink="/innovator/innovations/{{ innovationId }}/how-to-proceed/needs-reassessment-send"
-          [disabled]="!allSectionsSubmitted"
-          class="nhsuk-button nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-6"
-        >
-          Submit record for needs reassessment
-        </button>
-      </ng-container>
-
-      <ng-container *ngIf="showInnovatorShareRequestSection && pendingExportRequests">
+      @if (showInnovatorShareRequestSection && pendingExportRequests) {
         <div class="nhsuk-card">
           <div class="nhsuk-card__content">
             <h2 class="nhsuk-card__heading nhsuk-heading-m">
@@ -94,14 +77,9 @@
             </p>
           </div>
         </div>
-      </ng-container>
+      }
 
       <h2 class="nhsuk-heading-l">All sections</h2>
-      <ng-container *ngIf="ctx.user.isInnovator()">
-        <p *ngIf="isInnovationInCreatedStatus">
-          This is a live document for you to update as you develop your innovation. You can make changes to your innovation record even after submitting it for a needs assessment.
-        </p>
-      </ng-container>
 
       <ol class="app-task-list">
         <li *ngFor="let sectionGroup of innovationSections; let i = index">
@@ -199,33 +177,7 @@
 </theme-content-wrapper>
 
 <ng-template #icon let-status="status">
-  <theme-svg-icon *ngIf="status === 'NOT_STARTED'" type="error" customColor="grey"></theme-svg-icon>
+  <theme-svg-icon *ngIf="status === 'NOT_STARTED'" type="not-started" customColor="grey"></theme-svg-icon>
   <theme-svg-icon *ngIf="status === 'DRAFT'" type="edit"></theme-svg-icon>
   <theme-svg-icon *ngIf="status === 'SUBMITTED'" type="success"></theme-svg-icon>
-</ng-template>
-
-<ng-template #firstTimeBanner>
-  <div class="nhsuk-grid-column-full">
-    <div class="nhsuk-card nhsuk-card--care nhsuk-card--care--non-urgent nhsuk-u-margin-top-0">
-      <div class="nhsuk-card--care__heading-container">
-        <h2 class="nhsuk-card--care__heading">
-          <span role="text"><span class="nhsuk-u-visually-hidden">Information: </span>Welcome to your innovation record</span>
-        </h2>
-      </div>
-      <div class="nhsuk-card__content">
-        <p>To help us match you with support organisations, you'll need to:</p>
-        <ul>
-          <li>answer questions across the 11 sections of your innovation record</li>
-          <li>mark each section as complete</li>
-          <li>submit your record for a needs assessment</li>
-        </ul>
-        <p>Then, within 1 week, our team:</p>
-        <ul>
-          <li>will review your innovation record to assess your needs</li>
-          <li>notify appropriate support organisations</li>
-          <li>contact you with next steps</li>
-        </ul>
-      </div>
-    </div>
-  </div>
 </ng-template>

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.html
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.html
@@ -28,7 +28,7 @@
 
     <div class="nhsuk-grid-column-full">
       @if (showSubmit) {
-        @if (allSectionsSubmitted) {
+        @if (allSectionsSubmitted && !isReassessment) {
           <!-- This is very similar to the content on the innovation submission ready component -->
           <div class="nhsuk-card">
             <div class="nhsuk-card__content nhsuk-u-padding-4">
@@ -48,7 +48,8 @@
           <div class="nhsuk-card">
             <div class="nhsuk-card__content">
               <h2 class="nhsuk-card__heading nhsuk-heading-m">
-                {{ sections.incompleteSections }} sections to complete until you can submit for needs {{ isReassessment ? "reassessment" : "assessment" }}
+                {{ sections.incompleteSections }} {{ "dictionary.section" | pluralTranslate: sections.incompleteSections | translate }} to complete until you can submit for needs
+                {{ isReassessment ? "reassessment" : "assessment" }}
               </h2>
               <shared-innovation-record-progress [sections]="innovationSections" [firstSubmission]="!isReassessment" />
               <button type="submit" [routerLink]="submitUrl" [disabled]="!allSectionsSubmitted" class="nhsuk-button nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-2">

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.ts
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.ts
@@ -26,14 +26,7 @@ export class PageInnovationRecordComponent extends CoreComponent implements OnIn
   innovation: ContextInnovationType;
   pendingExportRequests = 0;
   innovationSections: SectionsSummaryModelV3Type = [];
-  sections: {
-    total: number;
-    submitted: number;
-    draft: number;
-    notStarted: number;
-    withOpenTasksCount: number;
-    openTasksCount: number;
-  } = { total: 0, submitted: 0, draft: 0, notStarted: 0, withOpenTasksCount: 0, openTasksCount: 0 };
+  sections = { total: 0, withOpenTasksCount: 0, openTasksCount: 0 };
 
   // Flags.
   isInnovationInCreatedStatus: boolean;
@@ -100,21 +93,9 @@ export class PageInnovationRecordComponent extends CoreComponent implements OnIn
         this.innovationSections = response;
         this.pendingExportRequests = this.ctx.user.isInnovator() ? statistics.PENDING_EXPORT_REQUESTS_COUNTER.count : 0;
 
-        this.sections.notStarted = this.innovationSections.reduce(
-          (acc: number, item) => acc + item.sections.filter(s => s.status === 'NOT_STARTED').length,
-          0
-        );
-        this.sections.draft = this.innovationSections.reduce(
-          (acc: number, item) => acc + item.sections.filter(s => s.status === 'DRAFT').length,
-          0
-        );
-        this.sections.submitted = this.innovationSections.reduce(
-          (acc: number, item) => acc + item.sections.filter(s => s.status === 'SUBMITTED').length,
-          0
-        );
-
-        this.sections.total = this.sections.notStarted + this.sections.draft + this.sections.submitted;
-        this.allSectionsSubmitted = this.sections.total === this.sections.submitted;
+        const sections = this.innovationSections.flatMap(s => s.sections);
+        this.allSectionsSubmitted = !sections.some(s => s.status !== 'SUBMITTED');
+        this.sections.total = sections.length;
 
         this.sections.withOpenTasksCount = this.innovationSections.reduce(
           (acc: number, item) => acc + item.sections.filter(s => s.openTasksCount > 0).length,

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.ts
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.ts
@@ -26,7 +26,7 @@ export class PageInnovationRecordComponent extends CoreComponent implements OnIn
   innovation: ContextInnovationType;
   pendingExportRequests = 0;
   innovationSections: SectionsSummaryModelV3Type = [];
-  sections = { total: 0, withOpenTasksCount: 0, openTasksCount: 0 };
+  sections = { incompleteSections: 0, withOpenTasksCount: 0, openTasksCount: 0 };
 
   // Flags.
   isInnovationInCreatedStatus: boolean;
@@ -94,8 +94,9 @@ export class PageInnovationRecordComponent extends CoreComponent implements OnIn
         this.pendingExportRequests = this.ctx.user.isInnovator() ? statistics.PENDING_EXPORT_REQUESTS_COUNTER.count : 0;
 
         const sections = this.innovationSections.flatMap(s => s.sections);
-        this.allSectionsSubmitted = !sections.some(s => s.status !== 'SUBMITTED');
-        this.sections.total = sections.length;
+        const incompleteSections = sections.filter(s => s.status !== 'SUBMITTED');
+        this.sections.incompleteSections = incompleteSections.length;
+        this.allSectionsSubmitted = incompleteSections.length === 0;
 
         this.sections.withOpenTasksCount = this.innovationSections.reduce(
           (acc: number, item) => acc + item.sections.filter(s => s.openTasksCount > 0).length,

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.ts
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.ts
@@ -71,7 +71,7 @@ export class PageInnovationRecordComponent extends CoreComponent implements OnIn
     ) {
       this.showSubmit = true;
       this.submitUrl = this.isReassessment
-        ? `/innovator/innovations/{{ innovationId }}/how-to-proceed/needs-reassessment-send`
+        ? `/innovator/innovations/${this.innovationId}/how-to-proceed/needs-reassessment-send`
         : `/innovator/innovations/${this.innovationId}/record/support`;
     }
   }

--- a/src/modules/shared/pipes/plural-translate.pipe.ts
+++ b/src/modules/shared/pipes/plural-translate.pipe.ts
@@ -1,6 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'pluralTranslate' })
+@Pipe({ name: 'pluralTranslate', standalone: true })
 export class PluralTranslatePipe implements PipeTransform {
   transform(translation: string, count?: null | number): string {
     switch (count) {

--- a/src/modules/shared/shared.module.ts
+++ b/src/modules/shared/shared.module.ts
@@ -127,6 +127,7 @@ import { TermsOfUseService } from './services/terms-of-use.service';
 import { UsersService } from './services/users.service';
 
 // Standalone components
+import { InnovationSubmissionReadyComponent } from '@modules/feature-modules/innovator/pages/innovation/submission-ready/innovation-submission-ready.component';
 import { InnovationRecordProgressComponent } from './pages/innovation/record/innovation-record-progress.component';
 
 @NgModule({
@@ -143,7 +144,8 @@ import { InnovationRecordProgressComponent } from './pages/innovation/record/inn
 
     // Standalone
     PluralTranslatePipe,
-    InnovationRecordProgressComponent
+    InnovationRecordProgressComponent,
+    InnovationSubmissionReadyComponent
   ],
   declarations: [
     // Pages.

--- a/src/modules/shared/shared.module.ts
+++ b/src/modules/shared/shared.module.ts
@@ -5,9 +5,9 @@ import { TranslateModule } from '@ngx-translate/core';
 import { DynamicModule } from 'ng-dynamic-component';
 
 // Modules.
+import { ReactiveFormsModule } from '@angular/forms';
 import { ThemeModule } from '@modules/theme/theme.module';
 import { FormsModule } from './forms/forms.module';
-import { ReactiveFormsModule } from '@angular/forms';
 
 // Pages.
 // // Account.
@@ -53,12 +53,12 @@ import { PageInnovationRecordDownloadComponent } from './pages/innovation/record
 import { PageInnovationRecordComponent } from './pages/innovation/record/innovation-record.component';
 import { PageInnovationSectionEvidenceInfoComponent } from './pages/innovation/sections/section-evidence-info.component';
 import { PageInnovationSectionInfoComponent } from './pages/innovation/sections/section-info.component';
+import { InnovationSectionSummaryComponent } from './pages/innovation/sections/section-summary.component';
 import { PageInnovationStatusListComponent } from './pages/innovation/status/innovation-status-list.component';
 import { PageInnovationSupportStatusListComponent } from './pages/innovation/support/support-status-list.component';
 import { PageInnovationSupportSummaryListComponent } from './pages/innovation/support/support-summary-list.component';
 import { PageInnovationSupportSummaryProgressUpdateDeleteComponent } from './pages/innovation/support/support-summary-progress-update-delete.component';
 import { PageInnovationSupportSummaryProgressUpdateWrapperComponent } from './pages/innovation/support/support-summary-progress-update-wrapper.component';
-import { InnovationSectionSummaryComponent } from './pages/innovation/sections/section-summary.component';
 // // Innovations.
 import { PageInnovationsAdvancedReviewComponent } from './pages/innovations/innovations-advanced-review.component';
 // // Notifications.
@@ -73,12 +73,12 @@ import { WizardSummaryWithConfirmStepComponent } from './wizards/steps/summary-w
 
 // Pipes.
 import { BytesPrettyPrintPipe } from './pipes/bytes-pretty-print.pipe';
-import { PluralTranslatePipe } from './pipes/plural-translate.pipe';
-import { ProgressCategoriesCategoryDescriptionPipe } from './pipes/progress-categories/subcategory-description.pipe';
-import { ProgressCategoriesSubcategoryDescriptionPipe } from './pipes/progress-categories/category-description.pipe';
-import { JoinArrayPipe } from './pipes/join-array.pipe';
-import { ServiceRoleTranslatePipe } from './pipes/service-role-translate.pipe';
 import { IrV3TranslatePipe } from './pipes/ir-v3-translate.pipe';
+import { JoinArrayPipe } from './pipes/join-array.pipe';
+import { PluralTranslatePipe } from './pipes/plural-translate.pipe';
+import { ProgressCategoriesSubcategoryDescriptionPipe } from './pipes/progress-categories/category-description.pipe';
+import { ProgressCategoriesCategoryDescriptionPipe } from './pipes/progress-categories/subcategory-description.pipe';
+import { ServiceRoleTranslatePipe } from './pipes/service-role-translate.pipe';
 
 // Components
 import { OrganisationSuggestionsCardComponent } from './pages/innovation/data-sharing-and-support/components/organisation-suggestion-card.component';
@@ -93,6 +93,31 @@ import { InnovationTaskDataResolver } from './resolvers/innovation-task-data.res
 import { InnovationThreadDataResolver } from './resolvers/innovation-thread-data.resolver';
 
 // Services.
+import { FileUploadService } from '@modules/shared/services/file-upload.service';
+import { FiltersSelectionWrapperComponent } from './components/filters-selection-wrapper/filters-selection-wrapper.component';
+import { FiltersWrapperComponent } from './components/filters-wrapper/filters-wrapper.component';
+import { PageSharedAccountManageAccountInfoComponent } from './pages/account/manage-account-info/manage-account-info.component';
+import { PageAccountMFAEditComponent } from './pages/account/mfa/mfa-edit.component';
+import { InnovationAssessmentDetailsComponent } from './pages/innovation/assessment/assessment-details.component';
+import { PageInnovationRecordWrapperComponent } from './pages/innovation/record/innovation-record-wrapper.component';
+import { PageInnovationAllSectionsInfoComponent } from './pages/innovation/sections/section-info-all.component';
+import { WizardInnovationSupportSummaryProgressUpdateMilestonesCategoriesStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update-milestones/steps/categories-step.component';
+import { WizardInnovationSupportSummaryProgressUpdateMilestonesDateStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update-milestones/steps/date-step.component';
+import { WizardInnovationSupportSummaryProgressUpdateMilestonesDescriptionStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update-milestones/steps/description-step.component';
+import { WizardInnovationSupportSummaryProgressUpdateMilestonesSubcategoriesStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update-milestones/steps/subcategories-step.component';
+import { WizardInnovationSupportSummaryProgressUpdateMilestonesSummaryStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update-milestones/steps/summary-step.component';
+import { WizardInnovationSupportSummaryProgressUpdateMilestonesComponent } from './pages/innovation/support/wizard-support-summary-progress-update-milestones/support-summary-progress-update-milestones.component';
+import { WizardInnovationSupportSummaryProgressUpdateAddDocumentStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update/steps/add-document-step.component';
+import { WizardInnovationSupportSummaryProgressUpdateDescriptionStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update/steps/description-step.component';
+import { WizardInnovationSupportSummaryProgressUpdateDocumentDescriptionStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update/steps/document-description-step.component';
+import { WizardInnovationSupportSummaryProgressUpdateDocumentFileStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update/steps/document-file-step.component';
+import { WizardInnovationSupportSummaryProgressUpdateDocumentNameStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update/steps/document-name-step.component';
+import { WizardInnovationSupportSummaryProgressUpdateSummaryStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update/steps/summary-step.component';
+import { WizardInnovationSupportSummaryProgressUpdateTitleStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update/steps/title-step.component';
+import { WizardInnovationSupportSummaryProgressUpdateComponent } from './pages/innovation/support/wizard-support-summary-progress-update/support-summary-progress-update.component';
+import { PageProgressCategoriesOneLevelMilestoneComponent } from './pages/progress-categories/progress-categories-one-level-milestone.component';
+import { PageProgressCategoriesTwoLevelMilestoneComponent } from './pages/progress-categories/progress-categories-two-level-milestone.component';
+import { PageProgressCategoriesWrapperComponent } from './pages/progress-categories/progress-categories-wrapper.component';
 import { InnovationDocumentsService } from './services/innovation-documents.service';
 import { InnovationsService } from './services/innovations.service';
 import { NotificationsService } from './services/notifications.service';
@@ -100,31 +125,9 @@ import { OrganisationsService } from './services/organisations.service';
 import { StatisticsService } from './services/statistics.service';
 import { TermsOfUseService } from './services/terms-of-use.service';
 import { UsersService } from './services/users.service';
-import { FileUploadService } from '@modules/shared/services/file-upload.service';
-import { PageInnovationAllSectionsInfoComponent } from './pages/innovation/sections/section-info-all.component';
-import { FiltersWrapperComponent } from './components/filters-wrapper/filters-wrapper.component';
-import { FiltersSelectionWrapperComponent } from './components/filters-selection-wrapper/filters-selection-wrapper.component';
-import { PageInnovationRecordWrapperComponent } from './pages/innovation/record/innovation-record-wrapper.component';
-import { WizardInnovationSupportSummaryProgressUpdateMilestonesComponent } from './pages/innovation/support/wizard-support-summary-progress-update-milestones/support-summary-progress-update-milestones.component';
-import { WizardInnovationSupportSummaryProgressUpdateMilestonesCategoriesStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update-milestones/steps/categories-step.component';
-import { WizardInnovationSupportSummaryProgressUpdateMilestonesSubcategoriesStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update-milestones/steps/subcategories-step.component';
-import { WizardInnovationSupportSummaryProgressUpdateMilestonesDescriptionStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update-milestones/steps/description-step.component';
-import { WizardInnovationSupportSummaryProgressUpdateMilestonesDateStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update-milestones/steps/date-step.component';
-import { WizardInnovationSupportSummaryProgressUpdateMilestonesSummaryStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update-milestones/steps/summary-step.component';
-import { PageAccountMFAEditComponent } from './pages/account/mfa/mfa-edit.component';
-import { PageSharedAccountManageAccountInfoComponent } from './pages/account/manage-account-info/manage-account-info.component';
-import { PageProgressCategoriesWrapperComponent } from './pages/progress-categories/progress-categories-wrapper.component';
-import { PageProgressCategoriesOneLevelMilestoneComponent } from './pages/progress-categories/progress-categories-one-level-milestone.component';
-import { PageProgressCategoriesTwoLevelMilestoneComponent } from './pages/progress-categories/progress-categories-two-level-milestone.component';
-import { InnovationAssessmentDetailsComponent } from './pages/innovation/assessment/assessment-details.component';
-import { WizardInnovationSupportSummaryProgressUpdateComponent } from './pages/innovation/support/wizard-support-summary-progress-update/support-summary-progress-update.component';
-import { WizardInnovationSupportSummaryProgressUpdateTitleStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update/steps/title-step.component';
-import { WizardInnovationSupportSummaryProgressUpdateDescriptionStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update/steps/description-step.component';
-import { WizardInnovationSupportSummaryProgressUpdateAddDocumentStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update/steps/add-document-step.component';
-import { WizardInnovationSupportSummaryProgressUpdateDocumentNameStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update/steps/document-name-step.component';
-import { WizardInnovationSupportSummaryProgressUpdateDocumentDescriptionStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update/steps/document-description-step.component';
-import { WizardInnovationSupportSummaryProgressUpdateDocumentFileStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update/steps/document-file-step.component';
-import { WizardInnovationSupportSummaryProgressUpdateSummaryStepComponent } from './pages/innovation/support/wizard-support-summary-progress-update/steps/summary-step.component';
+
+// Standalone components
+import { InnovationRecordProgressComponent } from './pages/innovation/record/innovation-record-progress.component';
 
 @NgModule({
   imports: [
@@ -136,7 +139,11 @@ import { WizardInnovationSupportSummaryProgressUpdateSummaryStepComponent } from
     // Modules.
     ThemeModule,
     FormsModule,
-    ReactiveFormsModule
+    ReactiveFormsModule,
+
+    // Standalone
+    PluralTranslatePipe,
+    InnovationRecordProgressComponent
   ],
   declarations: [
     // Pages.
@@ -226,7 +233,6 @@ import { WizardInnovationSupportSummaryProgressUpdateSummaryStepComponent } from
 
     // Pipes.
     BytesPrettyPrintPipe,
-    PluralTranslatePipe,
     JoinArrayPipe,
     ProgressCategoriesCategoryDescriptionPipe,
     ProgressCategoriesSubcategoryDescriptionPipe,


### PR DESCRIPTION
Multiple changes around removing the progress bar and changes depending on the innovation status:

# Before first submission
## Multiple sections to submit
![image](https://github.com/user-attachments/assets/59a3a3e3-611e-4b1e-ad70-c028af0c8903)

## 3 or less sections to submit
![image](https://github.com/user-attachments/assets/c77638c5-e3ef-4fb5-b17a-c24e64528b15)

## All sections ready
![image](https://github.com/user-attachments/assets/be915731-632a-48da-8d9d-98158feb963d)

# On reassessment
![image](https://github.com/user-attachments/assets/5874e9b5-0f40-43f1-b507-2d36f73d4789)

# Other roles
![image](https://github.com/user-attachments/assets/c333add8-d852-4e74-ba24-661c2b507a0d)

Closes: [AB#174980](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/174980)

