### PR TITLE
Feat/excel import export

### DIFF
--- a/src/app/config/translations/en.ts
+++ b/src/app/config/translations/en.ts
@@ -1162,6 +1162,7 @@ export const locale = {
           max_file_size: 'The file size is above the limit of 20MB',
           empty_file: 'Uploaded files cannot be empty',
           wrong_file_format: 'The file format is invalid. Files must be CSV, XLSX, DOCX or PDF',
+          wrong_template_file_format: 'The file format is invalid. File must be XLSX',
           upload_error: 'This file has failed to upload. Try again and if there is still a problem, contact us',
           invalid_date_input_format: 'Enter a valid date'
         }

--- a/src/modules/feature-modules/innovator/pages/dashboard/dashboard.component.html
+++ b/src/modules/feature-modules/innovator/pages/dashboard/dashboard.component.html
@@ -113,9 +113,9 @@
                 >Access our guidance on using the NHS Innovation Service (opens in a new window)</a
               >
             </li>
-            <li>
+            <!-- <li>
               <a href="javascript:void(0)" (click)="downloadExcelTemplate()">Download the Innovation Record Excel template (XLSX)</a>
-            </li>
+            </li> -->
             <li><a href="{{ CONSTANTS.URLS.ABOUT_THE_SERVICE }}" target="_blank" rel="noopener noreferrer">How does the innovation service work? (opens in a new window)</a></li>
           </ul>
         </div>

--- a/src/modules/feature-modules/innovator/pages/dashboard/dashboard.component.html
+++ b/src/modules/feature-modules/innovator/pages/dashboard/dashboard.component.html
@@ -113,6 +113,9 @@
                 >Access our guidance on using the NHS Innovation Service (opens in a new window)</a
               >
             </li>
+            <li>
+              <a href="javascript:void(0)" (click)="downloadExcelTemplate()">Download the Innovation Record Excel template (XLSX)</a>
+            </li>
             <li><a href="{{ CONSTANTS.URLS.ABOUT_THE_SERVICE }}" target="_blank" rel="noopener noreferrer">How does the innovation service work? (opens in a new window)</a></li>
           </ul>
         </div>

--- a/src/modules/feature-modules/innovator/pages/dashboard/dashboard.component.ts
+++ b/src/modules/feature-modules/innovator/pages/dashboard/dashboard.component.ts
@@ -203,6 +203,22 @@ export class PageDashboardComponent extends CoreComponent implements OnInit {
     this.announcements = this.announcements.filter(a => a.id !== announcementId);
   }
 
+  downloadExcelTemplate(): void {
+    this.innovationsService.getInnovationRecordExcelTemplate().subscribe({
+      next: (blob: Blob) => {
+        const url = window.URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `Innovation-Record-Template.xlsx`;
+        link.click();
+        window.URL.revokeObjectURL(url);
+      },
+      error: () => {
+        this.setAlertError('Unable to download the template. Please try again.');
+      }
+    });
+  }
+
   private buildDescriptionString(
     statistics: Pick<InnovationListFullDTO['statistics'], 'messages' | 'tasks'>
   ): string | null {

--- a/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.html
+++ b/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.html
@@ -1,14 +1,14 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
-    <ng-container *ngIf="wizard.isQuestionStep()">
+    <ng-container *ngIf="wizard.isQuestionStep() && !importSuccess">
       <h1 *ngIf="wizard.currentStep().label" class="nhsuk-heading-l">{{ wizard.currentStep().label }}</h1>
       <p *ngIf="wizard.currentStep().description">{{ wizard.currentStep().description }}</p>
 
       @if (wizard.isFirstStep()) {
         <div>
-          <p>We’ll ask you for the name and a brief description of the innovation, as well as your head office location and website.</p>
+          <p>We'll ask you for the name and a brief description of the innovation, as well as your head office location and website.</p>
           <p>
-            Once you’ve registered, we’ll ask you more detailed questions about your innovation in your innovation record. This will help us match you with appropriate support
+            Once you've registered, we'll ask you more detailed questions about your innovation in your innovation record. This will help us match you with appropriate support
             organisations for your innovation stage and type.
           </p>
           <p>The NHS Innovation Service is not suitable for innovations that are:</p>
@@ -23,34 +23,52 @@
             </li>
           </ul>
         </div>
-        <!-- TODO: This copy as to change with collaborators -->
-        <div class="nhsuk-inset-text">
-          <span class="nhsuk-u-visually-hidden">Information:</span>
-          <p>All innovations registered on this account should be developed by the same innovator or organisation.</p>
 
-          <div class="nhsuk-u-margin-top-4" style="border-top: 1px solid #d8dde0; padding-top: 20px;">
-            <p><strong>Already have a filled Excel record?</strong></p>
-            <p>You can skip the manual registration by uploading your Excel file instead.</p>
-            <input type="file" (change)="onExcelFileSelected($event)" accept=".xlsx" style="display: none" #excelFileInput />
-            <button
-              class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-0"
-              (click)="excelFileInput.click()"
-              [disabled]="isImportingExcel"
-              type="button"
-            >
-              {{ isImportingExcel ? "Importing..." : "Import from Excel" }}
-            </button>
+        <div class="nhsuk-card">
+          <div class="nhsuk-card__content">
+            <h3 class="nhsuk-card__heading nhsuk-u-margin-bottom-4">Start a new innovation</h3>
+            <!-- TODO: This copy as to change with collaborators -->
+            <p>All innovations registered on this account should be developed by the same innovator or organisation.</p>
+            <button type="button" class="nhsuk-button" (click)="onStartInnovation()">Start now</button>
+          </div>
+        </div>
+
+        <div class="nhsuk-card">
+          <div class="nhsuk-card__content">
+            <h3 class="nhsuk-card__heading nhsuk-u-margin-bottom-4">Import an existing innovation</h3>
+            <p>If you have already submitted your innovation on another NHS service (e.g. NIA), you can import it using our Excel template.</p>
+            <ol class="nhsuk-list nhsuk-list--bullet">
+              <li>
+                <p class="nhsuk-u-margin-bottom-3">Download the template</p>
+              </li>
+              <li>
+                <p class="nhsuk-u-margin-bottom-3">Add your innovation details into your template</p>
+              </li>
+              <li>
+                <p class="nhsuk-u-margin-bottom-3">Upload the completed template</p>
+              </li>
+            </ol>
+            <div class="nhsuk-inset-text nhsuk-u-padding-top-2 nhsuk-u-padding-bottom-2">
+              <p>Supporting documents cannot be imported. You will need to add these separately within each section.</p>
+            </div>
+            <button type="button" class="nhsuk-button nhsuk-u-margin-bottom-0 nhsuk-u-margin-right-3" (click)="downloadExcelTemplate()">Download template</button>
+            <button type="button" class="nhsuk-button nhsuk-button--secondary" (click)="onImportInnovation()">Upload template</button>
           </div>
         </div>
       }
 
       <theme-form-engine formId="addInnovationForm" [parameters]="wizard.currentStepParameters()" [values]="wizard.getAnswers()"></theme-form-engine>
-      <button type="submit" form="addInnovationForm" class="nhsuk-button" (click)="onSubmitStep('next')">
-        {{ wizard.isFirstStep() ? "Start now" : "Continue" }}
-      </button>
+
+      <ng-container *ngIf="isCreatingInnovation && !wizard.isFirstStep()">
+        <button type="submit" form="addInnovationForm" class="nhsuk-button" (click)="onSubmitStep('next')">Continue</button>
+      </ng-container>
+
+      <ng-container *ngIf="!isCreatingInnovation && !wizard.isFirstStep() && !importSuccess">
+        <button type="submit" form="addInnovationForm" class="nhsuk-button" (click)="onUploadTemplate()" [disabled]="isImportingExcel">Import innovation</button>
+      </ng-container>
     </ng-container>
 
-    <ng-container *ngIf="wizard.isSummaryStep()">
+    <ng-container *ngIf="isCreatingInnovation && wizard.isSummaryStep()">
       <h1 class="nhsuk-heading-l">Check your answers</h1>
 
       <div *ngFor="let item of wizard.getSummary()" class="nhsuk-summary-list__row">
@@ -63,7 +81,37 @@
         </dd>
       </div>
 
-      <button class="nhsuk-button nhsuk-u-margin-top-3" (click)="submitWizard()" [disabled]="isCreatingInnovation">Complete registration</button>
+      <button class="nhsuk-button nhsuk-u-margin-top-3" (click)="submitWizard()">Complete registration</button>
+    </ng-container>
+
+    <ng-container *ngIf="importSuccess">
+      <ng-container *ngIf="sectionsToFillAfterImport.length !== 0; else completeInnovationImport">
+        <p>Some information is still needed before you can submit your innovation.</p>
+        <p>You can add the remaining details in the Innovation Service, or update your Excel template and upload it again.</p>
+        <p class="nhsuk-u-font-weight-bold">Sections to complete:</p>
+        <ol class="nhsuk-list nhsuk-list--bullet">
+          <li *ngFor="let section of sectionsToFillAfterImport">
+            <p class="nhsuk-u-margin-bottom-3">{{ section }}</p>
+          </li>
+        </ol>
+      </ng-container>
+
+      <ng-template #completeInnovationImport>
+        <p>We have created your Innovation Record using the information you provided.</p>
+        <p>Please review your information before submitting.</p>
+      </ng-template>
+
+      <div class="nhsuk-inset-text">
+        <span class="nhsuk-u-visually-hidden">Information:</span>
+        <p>Supporting documents cannot be imported. You will need to add these separately within each evidence section.</p>
+      </div>
+
+         <div class="d-flex align-items-center">
+          <a routerLink="baseUrl" class="nhsuk-button nhsuk-u-margin-top-3 nhsuk-u-margin-right-5">Continue to the Innovation Record</a>
+          <div class="text-align-center">
+            <a *ngIf="!sectionsToFillAfterImport.length" [routerLink]="baseUrl">Cancel</a>
+          </div>
+        </div>
     </ng-container>
   </div>
 </div>

--- a/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.html
+++ b/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.html
@@ -28,7 +28,7 @@
           <div class="nhsuk-card__content">
             <h3 class="nhsuk-card__heading nhsuk-u-margin-bottom-4">Start a new innovation</h3>
             <!-- TODO: This copy as to change with collaborators -->
-            <p>All innovations registered on this account should be developed by the same innovator or organisation.</p>
+            <p>All innovations registered on this account should be developed by the same innovator or company.</p>
             <button type="button" class="nhsuk-button" (click)="onStartInnovation()">Start now</button>
           </div>
         </div>
@@ -36,20 +36,25 @@
         <div class="nhsuk-card">
           <div class="nhsuk-card__content">
             <h3 class="nhsuk-card__heading nhsuk-u-margin-bottom-4">Import an existing innovation</h3>
-            <p>If you have already submitted your innovation on another NHS service (e.g. NIA), you can import it using our Excel template.</p>
-            <ol class="nhsuk-list nhsuk-list--bullet">
+            <p class="nhsuk-u-margin-bottom-5">
+              If you have already submitted your innovation to another programme or platform and have a copy of the information, you can import it into the NHS Innovation Service
+              using an Excel template.
+            </p>
+            <p class="nhsuk-u-margin-bottom-2">To do this:</p>
+            <ol class="nhsuk-list nhsuk-list--bullet nhsuk-u-margin-left-2 nhsuk-u-font-weight-bold">
               <li>
-                <p class="nhsuk-u-margin-bottom-3">Download the template</p>
+                <p class="nhsuk-u-margin-bottom-3">Download the NHS Innovation Service template</p>
               </li>
               <li>
-                <p class="nhsuk-u-margin-bottom-3">Add your innovation details into your template</p>
+                <p class="nhsuk-u-margin-bottom-3">Add your innovation details</p>
               </li>
               <li>
-                <p class="nhsuk-u-margin-bottom-3">Upload the completed template</p>
+                <p class="nhsuk-u-margin-bottom-3">Upload the completed file</p>
               </li>
             </ol>
-            <div class="nhsuk-inset-text nhsuk-u-padding-top-2 nhsuk-u-padding-bottom-2">
-              <p>Supporting documents cannot be imported. You will need to add these separately within each section.</p>
+            <p class="nhsuk-u-margin-bottom-0">Make sure you don't alter the structure or format of the template, as the template must match exactly to import successfully.</p>
+            <div class="nhsuk-inset-text nhsuk-u-padding-top-2 nhsuk-u-padding-bottom-2 nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-4">
+              <p>Supporting documents cannot be imported through the template. You will need to add these separately within each section.</p>
             </div>
             <button type="button" class="nhsuk-button nhsuk-u-margin-bottom-0 nhsuk-u-margin-right-3" (click)="downloadExcelTemplate()">Download template</button>
             <button type="button" class="nhsuk-button nhsuk-button--secondary" (click)="onImportInnovation()">Upload template</button>
@@ -103,11 +108,13 @@
 
       <div class="nhsuk-inset-text">
         <span class="nhsuk-u-visually-hidden">Information:</span>
-        <p>Supporting documents cannot be imported. You will need to add these separately within each evidence section.</p>
+        <p>Supporting documents cannot be imported through the template. You will need to add these separately within each section.</p>
       </div>
 
       <div class="d-flex align-items-center nhsuk-u-margin-bottom-3">
-        <a routerLink="{{ baseUrl }}" class="nhsuk-button nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-3 nhsuk-u-margin-right-5">Continue to the Innovation Record</a>
+        <a routerLink="{{ baseUrl }}/innovations/{{ createdInnovationId }}/record" class="nhsuk-button nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-3 nhsuk-u-margin-right-5"
+          >Continue to the Innovation Record</a
+        >
         <div class="text-align-center">
           <a *ngIf="sectionsToFillAfterImport.length > 0" [routerLink]="baseUrl">Go back and resubmit</a>
         </div>

--- a/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.html
+++ b/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.html
@@ -106,12 +106,12 @@
         <p>Supporting documents cannot be imported. You will need to add these separately within each evidence section.</p>
       </div>
 
-         <div class="d-flex align-items-center">
-          <a routerLink="baseUrl" class="nhsuk-button nhsuk-u-margin-top-3 nhsuk-u-margin-right-5">Continue to the Innovation Record</a>
-          <div class="text-align-center">
-            <a *ngIf="!sectionsToFillAfterImport.length" [routerLink]="baseUrl">Cancel</a>
-          </div>
+      <div class="d-flex align-items-center nhsuk-u-margin-bottom-3">
+        <a routerLink="{{ baseUrl }}" class="nhsuk-button nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-3 nhsuk-u-margin-right-5">Continue to the Innovation Record</a>
+        <div class="text-align-center">
+          <a *ngIf="sectionsToFillAfterImport.length > 0" [routerLink]="baseUrl">Go back and resubmit</a>
         </div>
+      </div>
     </ng-container>
   </div>
 </div>

--- a/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.html
+++ b/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.html
@@ -27,6 +27,20 @@
         <div class="nhsuk-inset-text">
           <span class="nhsuk-u-visually-hidden">Information:</span>
           <p>All innovations registered on this account should be developed by the same innovator or organisation.</p>
+
+          <div class="nhsuk-u-margin-top-4" style="border-top: 1px solid #d8dde0; padding-top: 20px;">
+            <p><strong>Already have a filled Excel record?</strong></p>
+            <p>You can skip the manual registration by uploading your Excel file instead.</p>
+            <input type="file" (change)="onExcelFileSelected($event)" accept=".xlsx" style="display: none" #excelFileInput />
+            <button
+              class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-bottom-0"
+              (click)="excelFileInput.click()"
+              [disabled]="isImportingExcel"
+              type="button"
+            >
+              {{ isImportingExcel ? "Importing..." : "Import from Excel" }}
+            </button>
+          </div>
         </div>
       }
 

--- a/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.ts
@@ -28,7 +28,7 @@ export class InnovationNewComponent extends CoreComponent implements OnInit {
 
   createdInnovationId: undefined | string = undefined;
 
-  baseUrl = '/innovator/dashboard';
+  baseUrl = '/innovator';
 
   constructor(
     private innovatorService: InnovatorService,
@@ -159,6 +159,7 @@ export class InnovationNewComponent extends CoreComponent implements OnInit {
           if (err.error === InnovationErrorsEnum.INNOVATION_ALREADY_EXISTS) {
             this.setAlertError('An innovation with that name already exists. Try again with a new name');
           } else if (err.error === InnovationErrorsEnum.INNOVATION_INFO_EMPTY_INPUT) {
+            // TODO: confirm error copy
             this.setAlertError('Import failed as some mandatory fields are missing. Please try again.');
           } else {
             this.setAlertError(

--- a/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.ts
@@ -2,13 +2,15 @@ import { Component, OnInit, ViewChild } from '@angular/core';
 import { cloneDeep } from 'lodash';
 
 import { CoreComponent } from '@app/base';
-import { FormEngineComponent } from '@app/base/forms';
+import { FileTypes, FormEngineComponent, WizardEngineModel } from '@app/base/forms';
 
 import { InnovatorService } from '../../services/innovator.service';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { InnovationErrorsEnum } from '@app/base/enums';
-import { getNewInnovationQuestionsWizard } from './innovation-new.config';
+import { getImportInnovationQuestionsWizard, getNewInnovationQuestionsWizard } from './innovation-new.config';
+import { InnovationsService } from '@modules/shared/services/innovations.service';
+import {  switchMap } from 'rxjs';
 
 @Component({
   selector: 'app-innovator-pages-innovation-new',
@@ -17,41 +19,26 @@ import { getNewInnovationQuestionsWizard } from './innovation-new.config';
 export class InnovationNewComponent extends CoreComponent implements OnInit {
   @ViewChild(FormEngineComponent) formEngineComponent?: FormEngineComponent;
 
-  wizard = cloneDeep(getNewInnovationQuestionsWizard(this.ctx.schema.irSchemaInfo()));
+  wizard: WizardEngineModel = cloneDeep(getNewInnovationQuestionsWizard(this.ctx.schema.irSchemaInfo()));
 
   isCreatingInnovation = false;
+  isImportingInnovation = false;
+  isImportingExcel = false;
+  importSuccess = false;
+  sectionsToFillAfterImport: string[] = [];
 
-  constructor(private innovatorService: InnovatorService) {
+  createdInnovationId: undefined | string = undefined;
+
+  baseUrl = '/innovator/dashboard';
+
+  constructor(
+    private innovatorService: InnovatorService,
+    private innovationsService: InnovationsService
+  ) {
     super();
 
     this.setPageTitle('', { showPage: false });
     this.setBackLink('Go back', this.onSubmitStep.bind(this, 'previous'));
-  }
-
-  isImportingExcel = false;
-
-  onExcelFileSelected(event: any): void {
-    const file: File = event.target.files[0];
-    if (!file) return;
-
-    this.isImportingExcel = true;
-    const reader = new FileReader();
-
-    reader.onload = (e: any) => {
-      const base64 = e.target.result.split(',')[1];
-      this.innovatorService.createInnovationFromExcel(base64).subscribe({
-        next: response => {
-          this.setRedirectAlertSuccess(`Innovation successfully imported from Excel.`);
-          this.redirectTo(`innovator/innovations/${response.id}/registered`);
-        },
-        error: () => {
-          this.setAlertError('Failed to import from Excel. Please check the file format and try again.');
-          this.isImportingExcel = false;
-        }
-      });
-    };
-
-    reader.readAsDataURL(file);
   }
 
   ngOnInit(): void {
@@ -89,8 +76,9 @@ export class InnovationNewComponent extends CoreComponent implements OnInit {
 
     this.innovatorService.createInnovation(body).subscribe({
       next: response => {
+        this.createdInnovationId = response.id;
         this.setRedirectAlertSuccess(`You have successfully registered the innovation '${body.name}'`);
-        this.redirectTo(`innovator/innovations/${response.id}/registered`);
+        this.redirectTo(`innovator/innovations/${this.createdInnovationId}/registered`);
       },
       error: ({ error: err }: HttpErrorResponse) => {
         if (err.error === InnovationErrorsEnum.INNOVATION_ALREADY_EXISTS) {
@@ -120,5 +108,103 @@ export class InnovationNewComponent extends CoreComponent implements OnInit {
       default:
         break; // Should NOT happen!
     }
+  }
+
+  downloadExcelTemplate(): void {
+    this.innovationsService.getInnovationRecordExcelTemplate().subscribe({
+      next: (blob: Blob) => {
+        const url = window.URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `Innovation-Record-Template.xlsx`;
+        link.click();
+        window.URL.revokeObjectURL(url);
+      },
+      error: () => {
+        this.setAlertError('Unable to download the template. Please try again.');
+      }
+    });
+  }
+
+  onImportInnovation(): void {
+    this.isCreatingInnovation = false;
+    this.wizard = cloneDeep(getImportInnovationQuestionsWizard());
+    this.onSubmitStep('next');
+    this.setUploadConfiguration();
+  }
+
+  onStartInnovation(): void {
+    this.isCreatingInnovation = true;
+    this.wizard = cloneDeep(getNewInnovationQuestionsWizard(this.ctx.schema.irSchemaInfo()));
+    this.onSubmitStep('next');
+  }
+
+  onUploadTemplate(): void {
+    this.isImportingExcel = true;
+
+    const formData = this.formEngineComponent?.getFormValues() ?? { valid: false, data: {} };
+    const file = formData.data.file?.file;
+
+    this.fileToBase64(file).then(fileAsBase64 => {
+      this.innovatorService
+        .createInnovationFromExcel(fileAsBase64)
+        .pipe(
+          switchMap(response => {
+            this.createdInnovationId = response.id;
+            return this.ctx.innovation.getSectionsSummary$(response.id);
+          })
+        )
+        .subscribe({
+          next: sectionSummary => {
+            /*
+                get sections that are left incomplete after import
+                filter-out 2.2 and 5.1 (and any others with mandatory documents)
+              */
+
+            this.sectionsToFillAfterImport = sectionSummary.flatMap((section, i) =>
+              section.sections
+                .filter(
+                  s => !s.isCompleted && !['EVIDENCE_OF_EFFECTIVENESS', 'REGULATIONS_AND_STANDARDS'].includes(s.id)
+                )
+                .map((sub, j) => `${i + 1}.${j + 1} ${sub.title}`)
+            );
+
+            this.importSuccess = true;
+            this.setAlertSuccess('Your innovation has been imported');
+          },
+          error: ({ error: err }: HttpErrorResponse) => {
+            if (err.error === InnovationErrorsEnum.INNOVATION_ALREADY_EXISTS) {
+              this.setAlertError('An innovation with that name already exists. Try again with a new name');
+            } else {
+              this.setAlertError(
+                'An error occurred when importing the innovation. Please try again or contact us for further help'
+              );
+            }
+            
+            this.isImportingExcel = false;
+          }
+        });
+    });
+  }
+
+  private setUploadConfiguration(): void {
+    if (this.wizard.currentStep().parameters[0].dataType === 'file-upload') {
+      this.wizard.currentStep().parameters[0].fileUploadConfig = {
+        httpUploadUrl: '',
+        acceptedFiles: [FileTypes.XLSX],
+        localOnly: true
+      };
+    }
+  }
+
+  private fileToBase64(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+
+      reader.readAsDataURL(file);
+
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = error => reject(error);
+    });
   }
 }

--- a/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.ts
@@ -158,6 +158,8 @@ export class InnovationNewComponent extends CoreComponent implements OnInit {
         error: ({ error: err }: HttpErrorResponse) => {
           if (err.error === InnovationErrorsEnum.INNOVATION_ALREADY_EXISTS) {
             this.setAlertError('An innovation with that name already exists. Try again with a new name');
+          } else if (err.error === InnovationErrorsEnum.INNOVATION_INFO_EMPTY_INPUT) {
+            this.setAlertError('Import failed as some mandatory fields are missing. Please try again.');
           } else {
             this.setAlertError(
               'An error occurred when importing the innovation. Please try again or contact us for further help'

--- a/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.ts
@@ -28,6 +28,32 @@ export class InnovationNewComponent extends CoreComponent implements OnInit {
     this.setBackLink('Go back', this.onSubmitStep.bind(this, 'previous'));
   }
 
+  isImportingExcel = false;
+
+  onExcelFileSelected(event: any): void {
+    const file: File = event.target.files[0];
+    if (!file) return;
+
+    this.isImportingExcel = true;
+    const reader = new FileReader();
+
+    reader.onload = (e: any) => {
+      const base64 = e.target.result.split(',')[1];
+      this.innovatorService.createInnovationFromExcel(base64).subscribe({
+        next: response => {
+          this.setRedirectAlertSuccess(`Innovation successfully imported from Excel.`);
+          this.redirectTo(`innovator/innovations/${response.id}/registered`);
+        },
+        error: () => {
+          this.setAlertError('Failed to import from Excel. Please check the file format and try again.');
+          this.isImportingExcel = false;
+        }
+      });
+    };
+
+    reader.readAsDataURL(file);
+  }
+
   ngOnInit(): void {
     this.wizard.setAnswers(this.wizard.runInboundParsing({}));
   }

--- a/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.ts
@@ -4,13 +4,12 @@ import { cloneDeep } from 'lodash';
 import { CoreComponent } from '@app/base';
 import { FileTypes, FormEngineComponent, WizardEngineModel } from '@app/base/forms';
 
-import { InnovatorService } from '../../services/innovator.service';
+import { InnovationImportResponseType, InnovatorService } from '../../services/innovator.service';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { InnovationErrorsEnum } from '@app/base/enums';
 import { getImportInnovationQuestionsWizard, getNewInnovationQuestionsWizard } from './innovation-new.config';
 import { InnovationsService } from '@modules/shared/services/innovations.service';
-import {  switchMap } from 'rxjs';
 
 @Component({
   selector: 'app-innovator-pages-innovation-new',
@@ -146,44 +145,26 @@ export class InnovationNewComponent extends CoreComponent implements OnInit {
     const file = formData.data.file?.file;
 
     this.fileToBase64(file).then(fileAsBase64 => {
-      this.innovatorService
-        .createInnovationFromExcel(fileAsBase64)
-        .pipe(
-          switchMap(response => {
-            this.createdInnovationId = response.id;
-            return this.ctx.innovation.getSectionsSummary$(response.id);
-          })
-        )
-        .subscribe({
-          next: sectionSummary => {
-            /*
-                get sections that are left incomplete after import
-                filter-out 2.2 and 5.1 (and any others with mandatory documents)
-              */
+      this.innovatorService.createInnovationFromExcel(fileAsBase64).subscribe({
+        next: response => {
+          this.createdInnovationId = response.id;
+          this.sectionsToFillAfterImport = this.getNotCompletedSections(response);
 
-            this.sectionsToFillAfterImport = sectionSummary.flatMap((section, i) =>
-              section.sections
-                .filter(
-                  s => !s.isCompleted && !['EVIDENCE_OF_EFFECTIVENESS', 'REGULATIONS_AND_STANDARDS'].includes(s.id)
-                )
-                .map((sub, j) => `${i + 1}.${j + 1} ${sub.title}`)
+          this.importSuccess = true;
+          this.setAlertSuccess('Your innovation has been imported');
+        },
+        error: ({ error: err }: HttpErrorResponse) => {
+          if (err.error === InnovationErrorsEnum.INNOVATION_ALREADY_EXISTS) {
+            this.setAlertError('An innovation with that name already exists. Try again with a new name');
+          } else {
+            this.setAlertError(
+              'An error occurred when importing the innovation. Please try again or contact us for further help'
             );
-
-            this.importSuccess = true;
-            this.setAlertSuccess('Your innovation has been imported');
-          },
-          error: ({ error: err }: HttpErrorResponse) => {
-            if (err.error === InnovationErrorsEnum.INNOVATION_ALREADY_EXISTS) {
-              this.setAlertError('An innovation with that name already exists. Try again with a new name');
-            } else {
-              this.setAlertError(
-                'An error occurred when importing the innovation. Please try again or contact us for further help'
-              );
-            }
-            
-            this.isImportingExcel = false;
           }
-        });
+
+          this.isImportingExcel = false;
+        }
+      });
     });
   }
 
@@ -206,5 +187,16 @@ export class InnovationNewComponent extends CoreComponent implements OnInit {
       reader.onload = () => resolve(reader.result as string);
       reader.onerror = error => reject(error);
     });
+  }
+
+  private getNotCompletedSections(res: InnovationImportResponseType): string[] {
+    const withErrors = Object.keys(res.validationIssues).filter(id => id !== 'GLOBAL_WARNING');
+    const empty = res.emptySections;
+
+    const sections = [...new Set([...withErrors, ...empty])];
+
+    const numberedSections = sections.map(s => this.ctx.schema.getNumberedTranslatedSection(s));
+
+    return numberedSections;
   }
 }

--- a/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.ts
@@ -54,6 +54,8 @@ export class InnovationNewComponent extends CoreComponent implements OnInit {
 
     this.wizard.addAnswers(formData.data).runRules();
 
+    this.resetAlert();
+
     this.navigateTo(action);
   }
 
@@ -173,7 +175,8 @@ export class InnovationNewComponent extends CoreComponent implements OnInit {
       this.wizard.currentStep().parameters[0].fileUploadConfig = {
         httpUploadUrl: '',
         acceptedFiles: [FileTypes.XLSX],
-        localOnly: true
+        localOnly: true,
+        customValidationError: { wrongTemplateFileFormat: true }
       };
     }
   }

--- a/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.component.ts
@@ -45,6 +45,13 @@ export class InnovationNewComponent extends CoreComponent implements OnInit {
   }
 
   onSubmitStep(action: 'previous' | 'next'): void {
+    if (action === 'previous' && this.importSuccess) {
+      this.importSuccess = false;
+      this.resetAlert();
+      this.navigateTo(action);
+      return;
+    }
+
     const formData = this.formEngineComponent?.getFormValues() ?? { valid: false, data: {} };
 
     if (action === 'next' && !formData.valid) {
@@ -129,6 +136,7 @@ export class InnovationNewComponent extends CoreComponent implements OnInit {
 
   onImportInnovation(): void {
     this.isCreatingInnovation = false;
+    this.importSuccess = false;
     this.wizard = cloneDeep(getImportInnovationQuestionsWizard());
     this.onSubmitStep('next');
     this.setUploadConfiguration();
@@ -146,31 +154,43 @@ export class InnovationNewComponent extends CoreComponent implements OnInit {
     const formData = this.formEngineComponent?.getFormValues() ?? { valid: false, data: {} };
     const file = formData.data.file?.file;
 
-    this.fileToBase64(file).then(fileAsBase64 => {
-      this.innovatorService.createInnovationFromExcel(fileAsBase64).subscribe({
-        next: response => {
-          this.createdInnovationId = response.id;
-          this.sectionsToFillAfterImport = this.getNotCompletedSections(response);
+    if (!file) {
+      this.isImportingExcel = false;
+      this.setAlertError('Please select a file to import');
+      return;
+    }
 
-          this.importSuccess = true;
-          this.setAlertSuccess('Your innovation has been imported');
-        },
-        error: ({ error: err }: HttpErrorResponse) => {
-          if (err.error === InnovationErrorsEnum.INNOVATION_ALREADY_EXISTS) {
-            this.setAlertError('An innovation with that name already exists. Try again with a new name');
-          } else if (err.error === InnovationErrorsEnum.INNOVATION_INFO_EMPTY_INPUT) {
-            // TODO: confirm error copy
-            this.setAlertError('Import failed as some mandatory fields are missing. Please try again.');
-          } else {
-            this.setAlertError(
-              'An error occurred when importing the innovation. Please try again or contact us for further help'
-            );
+    this.fileToBase64(file)
+      .then(fileAsBase64 => {
+        this.innovatorService.createInnovationFromExcel(fileAsBase64).subscribe({
+          next: response => {
+            this.createdInnovationId = response.id;
+            this.sectionsToFillAfterImport = this.getNotCompletedSections(response);
+
+            this.importSuccess = true;
+            this.isImportingExcel = false;
+            this.setAlertSuccess('Your innovation has been imported');
+          },
+          error: ({ error: err }: HttpErrorResponse) => {
+            if (err.error === InnovationErrorsEnum.INNOVATION_ALREADY_EXISTS) {
+              this.setAlertError('An innovation with that name already exists. Try again with a new name');
+            } else if (err.error === InnovationErrorsEnum.INNOVATION_INFO_EMPTY_INPUT) {
+              // TODO: confirm error copy
+              this.setAlertError('Import failed as some mandatory fields are missing. Please try again.');
+            } else {
+              this.setAlertError(
+                'An error occurred when importing the innovation. Please try again or contact us for further help'
+              );
+            }
+
+            this.isImportingExcel = false;
           }
-
-          this.isImportingExcel = false;
-        }
+        });
+      })
+      .catch(() => {
+        this.isImportingExcel = false;
+        this.setAlertError('An error occurred when processing the file. Please try again.');
       });
-    });
   }
 
   private setUploadConfiguration(): void {

--- a/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.config.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.config.ts
@@ -5,7 +5,7 @@ import {
   WizardStepType,
   WizardSummaryType
 } from '@modules/shared/forms';
-import { INPUT_LENGTH_LIMIT } from '@modules/shared/forms/engine/config/form-engine.config';
+import { FileUploadType, INPUT_LENGTH_LIMIT } from '@modules/shared/forms/engine/config/form-engine.config';
 import { InnovationRecordSchemaInfoType } from '@modules/stores/ctx/schema/schema.types';
 import { getIrSchemaQuestionItemsValueAndLabel } from '@modules/stores/innovation/innovation-record/202405/ir-v3-schema-translation.helper';
 
@@ -33,7 +33,7 @@ const stepsLabels = {
 };
 
 // Types.
-type StepPayloadType = {
+type NewInnovationStepPayloadType = {
   name: string;
   description?: string;
   officeLocation: string;
@@ -45,7 +45,11 @@ type StepPayloadType = {
   videoDemonstrationUrl?: string;
 };
 
-type OutboundPayloadType = {
+type ImportInnovationStepPayloadType = {
+  file: FileUploadType;
+};
+
+type NewInnovationOutboundPayloadType = {
   name: string;
   description: string;
   officeLocation: string;
@@ -56,6 +60,31 @@ type OutboundPayloadType = {
   hasVideoDemonstration?: string;
   videoDemonstrationUrl?: string;
 };
+
+export function getImportInnovationQuestionsWizard(): WizardEngineModel {
+  return new WizardEngineModel({
+    showSummary: false,
+    steps: [
+      new FormEngineModel({
+        label: 'Register a new innovation',
+        parameters: []
+      }),
+      new FormEngineModel({
+        label: 'Import an existing innovation',
+
+        parameters: [
+          {
+            id: 'file',
+            dataType: 'file-upload',
+            validations: { isRequired: [true, 'You need to upload 1 file'] }
+          }
+        ]
+      })
+    ],
+    outboundParsing: (data: ImportInnovationStepPayloadType) => ImportInnovationOutboundParsing(data),
+
+  });
+}
 
 export function getNewInnovationQuestionsWizard(currentSchema: InnovationRecordSchemaInfoType): WizardEngineModel {
   return new WizardEngineModel({
@@ -107,19 +136,19 @@ export function getNewInnovationQuestionsWizard(currentSchema: InnovationRecordS
     runtimeRules: [
       (
         steps: WizardStepType[],
-        currentValues: StepPayloadType,
+        currentValues: NewInnovationStepPayloadType,
         currentStep: number | 'summary',
         schema?: InnovationRecordSchemaInfoType
       ) => runtimeRules(steps, currentValues, currentStep, currentSchema)
     ],
-    outboundParsing: (data: StepPayloadType) => outboundParsing(data),
-    summaryParsing: (data: StepPayloadType) => summaryParsing(data)
+    outboundParsing: (data: NewInnovationStepPayloadType) => NewInnovationOutboundParsing(data),
+    summaryParsing: (data: NewInnovationStepPayloadType) => summaryParsing(data)
   });
 }
 
 function runtimeRules(
   steps: WizardStepType[],
-  currentValues: StepPayloadType,
+  currentValues: NewInnovationStepPayloadType,
   currentStep: number | 'summary',
   schema?: InnovationRecordSchemaInfoType
 ): void {
@@ -216,7 +245,7 @@ function runtimeRules(
   );
 }
 
-function outboundParsing(data: StepPayloadType): OutboundPayloadType {
+function NewInnovationOutboundParsing(data: NewInnovationStepPayloadType): NewInnovationOutboundPayloadType {
   return {
     name: data.name.trim(),
     description: data.description ?? '',
@@ -230,7 +259,13 @@ function outboundParsing(data: StepPayloadType): OutboundPayloadType {
   };
 }
 
-function summaryParsing(data: StepPayloadType): WizardSummaryType[] {
+function ImportInnovationOutboundParsing (data: ImportInnovationStepPayloadType): ImportInnovationStepPayloadType {
+  return {
+    file: data.file
+  }
+}
+
+function summaryParsing(data: NewInnovationStepPayloadType): WizardSummaryType[] {
   const toReturn: WizardSummaryType[] = [];
 
   let editStepNumber = 2;

--- a/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.config.ts
+++ b/src/modules/feature-modules/innovator/pages/innovation-new/innovation-new.config.ts
@@ -76,13 +76,14 @@ export function getImportInnovationQuestionsWizard(): WizardEngineModel {
           {
             id: 'file',
             dataType: 'file-upload',
+            description: `<p>Upload the completed Excel (.xlsx) template you downloaded from this service.</p>
+<p class="nhsuk-u-margin-top-4">Make sure you don't alter the structure or format of the template, as it must match exactly to import successfully.</p>`,
             validations: { isRequired: [true, 'You need to upload 1 file'] }
           }
         ]
       })
     ],
-    outboundParsing: (data: ImportInnovationStepPayloadType) => ImportInnovationOutboundParsing(data),
-
+    outboundParsing: (data: ImportInnovationStepPayloadType) => ImportInnovationOutboundParsing(data)
   });
 }
 
@@ -259,10 +260,10 @@ function NewInnovationOutboundParsing(data: NewInnovationStepPayloadType): NewIn
   };
 }
 
-function ImportInnovationOutboundParsing (data: ImportInnovationStepPayloadType): ImportInnovationStepPayloadType {
+function ImportInnovationOutboundParsing(data: ImportInnovationStepPayloadType): ImportInnovationStepPayloadType {
   return {
     file: data.file
-  }
+  };
 }
 
 function summaryParsing(data: NewInnovationStepPayloadType): WizardSummaryType[] {

--- a/src/modules/feature-modules/innovator/services/innovator.service.ts
+++ b/src/modules/feature-modules/innovator/services/innovator.service.ts
@@ -84,8 +84,8 @@ export class InnovatorService extends CoreService {
   }
 
   createInnovationFromExcel(base64File: string): Observable<{ id: string }> {
-    const url = new UrlModel(this.API_INNOVATIONS_URL).addPath('v1/innovations/xlsx');
-    return this.http.post<{ id: string }>(url.buildUrl(), { file: base64File }).pipe(take(1));
+    const url = new UrlModel(this.API_INNOVATIONS_URL).addPath('v1/innovations/import');
+    return this.http.post<{ id: string }>(url.buildUrl(), { format: 'excel', file: base64File }).pipe(take(1));
   }
 
   submitOrganisationSharing(innovationId: string, body: MappedObjectType): Observable<{ id: string }> {

--- a/src/modules/feature-modules/innovator/services/innovator.service.ts
+++ b/src/modules/feature-modules/innovator/services/innovator.service.ts
@@ -83,6 +83,11 @@ export class InnovatorService extends CoreService {
     );
   }
 
+  createInnovationFromExcel(base64File: string): Observable<{ id: string }> {
+    const url = new UrlModel(this.API_INNOVATIONS_URL).addPath('v1/innovations/xlsx');
+    return this.http.post<{ id: string }>(url.buildUrl(), { file: base64File }).pipe(take(1));
+  }
+
   submitOrganisationSharing(innovationId: string, body: MappedObjectType): Observable<{ id: string }> {
     const url = new UrlModel(this.API_INNOVATIONS_URL)
       .addPath('v1/:innovationId/shares')

--- a/src/modules/feature-modules/innovator/services/innovator.service.ts
+++ b/src/modules/feature-modules/innovator/services/innovator.service.ts
@@ -64,6 +64,12 @@ export type SurveyAnswersType = {
   comment: string;
 };
 
+export type InnovationImportResponseType = {
+  id: string;
+  validationIssues: Record<string, string[]>;
+  emptySections: string[];
+};
+
 @Injectable()
 export class InnovatorService extends CoreService {
   constructor() {
@@ -83,9 +89,11 @@ export class InnovatorService extends CoreService {
     );
   }
 
-  createInnovationFromExcel(base64File: string): Observable<{ id: string }> {
+  createInnovationFromExcel(base64File: string): Observable<InnovationImportResponseType> {
     const url = new UrlModel(this.API_INNOVATIONS_URL).addPath('v1/innovations/import');
-    return this.http.post<{ id: string }>(url.buildUrl(), { format: 'excel', file: base64File }).pipe(take(1));
+    return this.http
+      .post<InnovationImportResponseType>(url.buildUrl(), { format: 'excel', file: base64File })
+      .pipe(take(1));
   }
 
   submitOrganisationSharing(innovationId: string, body: MappedObjectType): Observable<{ id: string }> {

--- a/src/modules/shared/forms/components/file-upload.component.html
+++ b/src/modules/shared/forms/components/file-upload.component.html
@@ -42,17 +42,18 @@
       [maxFileSize]="dzConfig.maxFileSize"
       (change)="onChange($event)"
       [disabled]="isLoadingFile"
-      [disableClick]="true"
+      [disableClick]="false"
+      class="cursor-pointer"
     >
-      <ngx-dropzone-label>
-        <label for="{{ id }}" class="cursor-pointer">Click or drop your file here</label>
+      <ngx-dropzone-label *ngIf="!uploadedFile">
+        <p class="nhsuk-u-margin-bottom-0">Click or drop your file here</p>
       </ngx-dropzone-label>
       <theme-file-upload-preview
         *ngIf="uploadedFile"
         [removable]="true"
-        (removed)="onRemoveUploadedFile()"
-        (click)="onRemoveUploadedFile()"
-        (keypress)="onRemoveUploadedFile()"
+        (removed)="onRemoveUploadedFile($event)"
+        (click)="onRemoveUploadedFile($event)"
+        (keypress)="onRemoveUploadedFile($event)"
         attr.aria-label="Delete {{ uploadedFile.file.name }}"
         class="cursor-pointer"
         role="button"

--- a/src/modules/shared/forms/components/file-upload.component.ts
+++ b/src/modules/shared/forms/components/file-upload.component.ts
@@ -34,8 +34,7 @@ export class FormFileUploadComponent implements OnInit, DoCheck {
           acceptedFiles?: FileTypes[];
           maxFileSize?: number; // In Mb.
           localOnly?: boolean;
-              customValidationError?: ValidationErrors;
-
+          customValidationError?: ValidationErrors;
         }
   ) {
     this.fileConfig = {
@@ -170,7 +169,7 @@ export class FormFileUploadComponent implements OnInit, DoCheck {
       if (wrongFormat) {
         this.hasUploadError = true;
         this.error = FormEngineHelper.getValidationMessage({ wrongFileFormat: 'true' });
-        console.log('this.fileConfig', this.fileConfig);
+
         if (this.fileConfig.localOnly && this.fileConfig.customValidationError) {
           this.error = FormEngineHelper.getValidationMessage(this.fileConfig.customValidationError);
         }

--- a/src/modules/shared/forms/components/file-upload.component.ts
+++ b/src/modules/shared/forms/components/file-upload.component.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DoCheck, Injector, Input, OnInit } from '@angular/core';
-import { AbstractControl, ControlContainer, FormControl, FormGroup } from '@angular/forms';
+import { AbstractControl, ControlContainer, FormControl, FormGroup, ValidationErrors } from '@angular/forms';
 import { NgxDropzoneChangeEvent } from 'ngx-dropzone';
 import { Observable, of } from 'rxjs';
 import { map, take } from 'rxjs/operators';
@@ -33,13 +33,16 @@ export class FormFileUploadComponent implements OnInit, DoCheck {
           httpUploadBody?: Record<string, any>;
           acceptedFiles?: FileTypes[];
           maxFileSize?: number; // In Mb.
-          localOnly?:boolean;
+          localOnly?: boolean;
+              customValidationError?: ValidationErrors;
+
         }
   ) {
     this.fileConfig = {
       httpUploadUrl: c?.httpUploadUrl ?? '',
       httpUploadBody: c?.httpUploadBody,
-      localOnly: c?.localOnly
+      localOnly: c?.localOnly,
+      customValidationError: c?.customValidationError
     };
 
     this.dzConfig = {
@@ -61,6 +64,7 @@ export class FormFileUploadComponent implements OnInit, DoCheck {
     httpUploadUrl: string;
     httpUploadBody?: Record<string, any>;
     localOnly?: boolean;
+    customValidationError?: ValidationErrors;
   } = { httpUploadUrl: '' };
 
   dzConfig: {
@@ -130,14 +134,14 @@ export class FormFileUploadComponent implements OnInit, DoCheck {
     formdata.append('file', file, file.name);
     Object.entries(this.fileConfig?.httpUploadBody || {}).forEach(([key, value]) => formdata.append(key, value));
 
-    if(this.fileConfig.localOnly){
+    if (this.fileConfig.localOnly) {
       return of({
-        id:'',
+        id: '',
         name: file.name,
-        extension:file.type,
-        url:'',
+        extension: file.type,
+        url: '',
         file: file
-      })
+      });
     }
 
     return this.http.post<FileUploadType>(this.fileConfig?.httpUploadUrl || '', formdata).pipe(
@@ -166,6 +170,10 @@ export class FormFileUploadComponent implements OnInit, DoCheck {
       if (wrongFormat) {
         this.hasUploadError = true;
         this.error = FormEngineHelper.getValidationMessage({ wrongFileFormat: 'true' });
+        console.log('this.fileConfig', this.fileConfig);
+        if (this.fileConfig.localOnly && this.fileConfig.customValidationError) {
+          this.error = FormEngineHelper.getValidationMessage(this.fileConfig.customValidationError);
+        }
       }
 
       event.rejectedFiles.forEach(file => {
@@ -199,7 +207,7 @@ export class FormFileUploadComponent implements OnInit, DoCheck {
             this.fieldGroupControl.addControl('size', new FormControl(response.size));
             this.fieldGroupControl.addControl('extension', new FormControl(response.extension));
             this.fieldGroupControl.addControl('url', new FormControl(response.url));
-            response.file && this.fieldGroupControl.addControl('file',new FormControl(response.file) )
+            response.file && this.fieldGroupControl.addControl('file', new FormControl(response.file));
 
             this.evaluateDropZoneTabIndex();
             this.setAuxMessageAndFocus(`${file.name} added.`);

--- a/src/modules/shared/forms/components/file-upload.component.ts
+++ b/src/modules/shared/forms/components/file-upload.component.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DoCheck, Injector, Input, OnInit } from '@angular/core';
 import { AbstractControl, ControlContainer, FormControl, FormGroup } from '@angular/forms';
 import { NgxDropzoneChangeEvent } from 'ngx-dropzone';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 
 import { RandomGeneratorHelper } from '@modules/core/helpers/random-generator.helper';
@@ -33,11 +33,13 @@ export class FormFileUploadComponent implements OnInit, DoCheck {
           httpUploadBody?: Record<string, any>;
           acceptedFiles?: FileTypes[];
           maxFileSize?: number; // In Mb.
+          localOnly?:boolean;
         }
   ) {
     this.fileConfig = {
       httpUploadUrl: c?.httpUploadUrl ?? '',
-      httpUploadBody: c?.httpUploadBody
+      httpUploadBody: c?.httpUploadBody,
+      localOnly: c?.localOnly
     };
 
     this.dzConfig = {
@@ -58,6 +60,7 @@ export class FormFileUploadComponent implements OnInit, DoCheck {
   fileConfig: {
     httpUploadUrl: string;
     httpUploadBody?: Record<string, any>;
+    localOnly?: boolean;
   } = { httpUploadUrl: '' };
 
   dzConfig: {
@@ -127,6 +130,16 @@ export class FormFileUploadComponent implements OnInit, DoCheck {
     formdata.append('file', file, file.name);
     Object.entries(this.fileConfig?.httpUploadBody || {}).forEach(([key, value]) => formdata.append(key, value));
 
+    if(this.fileConfig.localOnly){
+      return of({
+        id:'',
+        name: file.name,
+        extension:file.type,
+        url:'',
+        file: file
+      })
+    }
+
     return this.http.post<FileUploadType>(this.fileConfig?.httpUploadUrl || '', formdata).pipe(
       take(1),
       map(response => response)
@@ -137,7 +150,7 @@ export class FormFileUploadComponent implements OnInit, DoCheck {
     this.hasError = false;
     this.hasUploadError = false;
 
-    if (!this.fileConfig.httpUploadUrl) {
+    if (!this.fileConfig.httpUploadUrl && !this.fileConfig.localOnly) {
       console.error('No httpUploadUrl provided for file upload.');
       return;
     }
@@ -186,6 +199,7 @@ export class FormFileUploadComponent implements OnInit, DoCheck {
             this.fieldGroupControl.addControl('size', new FormControl(response.size));
             this.fieldGroupControl.addControl('extension', new FormControl(response.extension));
             this.fieldGroupControl.addControl('url', new FormControl(response.url));
+            response.file && this.fieldGroupControl.addControl('file',new FormControl(response.file) )
 
             this.evaluateDropZoneTabIndex();
             this.setAuxMessageAndFocus(`${file.name} added.`);

--- a/src/modules/shared/forms/components/file-upload.component.ts
+++ b/src/modules/shared/forms/components/file-upload.component.ts
@@ -206,7 +206,9 @@ export class FormFileUploadComponent implements OnInit, DoCheck {
             this.fieldGroupControl.addControl('size', new FormControl(response.size));
             this.fieldGroupControl.addControl('extension', new FormControl(response.extension));
             this.fieldGroupControl.addControl('url', new FormControl(response.url));
-            response.file && this.fieldGroupControl.addControl('file', new FormControl(response.file));
+            if (response.file) {
+              this.fieldGroupControl.addControl('file', new FormControl(response.file));
+            }
 
             this.evaluateDropZoneTabIndex();
             this.setAuxMessageAndFocus(`${file.name} added.`);
@@ -230,13 +232,17 @@ export class FormFileUploadComponent implements OnInit, DoCheck {
     }
   }
 
-  onRemoveUploadedFile(): void {
+  onRemoveUploadedFile(event?: unknown): void {
+    if (event instanceof Event) {
+      event.stopPropagation();
+    }
     this.uploadedFile = null;
     this.fieldGroupControl.removeControl('id');
     this.fieldGroupControl.removeControl('name');
     this.fieldGroupControl.removeControl('size');
     this.fieldGroupControl.removeControl('extension');
     this.fieldGroupControl.removeControl('url');
+    this.fieldGroupControl.removeControl('file');
     this.cdr.detectChanges();
   }
 
@@ -247,6 +253,7 @@ export class FormFileUploadComponent implements OnInit, DoCheck {
     this.fieldGroupControl.removeControl('size');
     this.fieldGroupControl.removeControl('extension');
     this.fieldGroupControl.removeControl('url');
+    this.fieldGroupControl.removeControl('file');
     this.cdr.detectChanges();
   }
 

--- a/src/modules/shared/forms/engine/config/form-engine.config.ts
+++ b/src/modules/shared/forms/engine/config/form-engine.config.ts
@@ -4,6 +4,7 @@ export type FileUploadType = {
   size?: number;
   extension: string;
   url: string;
+  file?: File
 };
 
 export enum FileTypes {

--- a/src/modules/shared/forms/engine/config/form-engine.config.ts
+++ b/src/modules/shared/forms/engine/config/form-engine.config.ts
@@ -4,7 +4,7 @@ export type FileUploadType = {
   size?: number;
   extension: string;
   url: string;
-  file?: File
+  file?: File;
 };
 
 export enum FileTypes {

--- a/src/modules/shared/forms/engine/helpers/form-engine.helper.ts
+++ b/src/modules/shared/forms/engine/helpers/form-engine.helper.ts
@@ -312,6 +312,9 @@ export class FormEngineHelper {
     if (error.wrongFileFormat) {
       return { message: 'shared.forms_module.validations.wrong_file_format', params: {} };
     }
+    if (error.wrongTemplateFileFormat) {
+      return { message: 'shared.forms_module.validations.wrong_template_file_format', params: {} };
+    }
     if (error.uploadError) {
       return { message: 'shared.forms_module.validations.upload_error', params: {} };
     }

--- a/src/modules/shared/forms/engine/models/form-engine.models.ts
+++ b/src/modules/shared/forms/engine/models/form-engine.models.ts
@@ -1,4 +1,4 @@
-import { AsyncValidatorFn } from '@angular/forms';
+import { AsyncValidatorFn, ValidationErrors } from '@angular/forms';
 
 import { FileTypes, TextareaLengthLimitType } from '../config/form-engine.config';
 import { SelectComponentInputType } from '@modules/theme/components/search/select.component';
@@ -109,7 +109,8 @@ export class FormEngineParameterModel {
     acceptedFiles?: FileTypes[];
     maxFileSize?: number; // In Mb.
     previousUploadedFiles?: { id: string; name: string }[];
-    localOnly?:boolean
+    localOnly?: boolean;
+    customValidationError?: ValidationErrors;
   };
 
   selectItems?: { selectList: SelectComponentInputType[]; defaultKey: string };

--- a/src/modules/shared/forms/engine/models/form-engine.models.ts
+++ b/src/modules/shared/forms/engine/models/form-engine.models.ts
@@ -109,6 +109,7 @@ export class FormEngineParameterModel {
     acceptedFiles?: FileTypes[];
     maxFileSize?: number; // In Mb.
     previousUploadedFiles?: { id: string; name: string }[];
+    localOnly?:boolean
   };
 
   selectItems?: { selectList: SelectComponentInputType[]; defaultKey: string };
@@ -159,15 +160,6 @@ export class FormEngineModelV3 {
 export class FormEngineParameterModelV3 {
   id: string;
   dataType: InnovationRecordFormComponentType;
-  // | 'number'
-  // | 'password'
-  // | 'hidden'
-  // | 'date'
-  // | 'checkbox-group'
-  // | 'grouped-checkbox-array'
-  // | 'file-upload'
-  // | 'file-upload-array'
-  // | 'select-component';
   label?: string;
   description?: string;
   checkboxAnswerId?: string;

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.html
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.html
@@ -156,7 +156,7 @@
       @if (ctx.user.isInnovator()) {
         <ul class="nhsuk-u-margin-bottom-7">
           <li><a href="javascript:void(0)" (click)="downloadInnovationRecordDocument()">Download all the questions (DOCX)</a> in your innovation record</li>
-          <li><a href="javascript:void(0)" (click)="downloadInnovationRecordExcel()">Download the Innovation Record as Excel (XLSX)</a></li>
+          <!-- <li><a href="javascript:void(0)" (click)="downloadInnovationRecordExcel()">Download the Innovation Record as Excel (XLSX)</a></li> -->
           <li><app-innovation-record-export [innovationId]="this.innovationId" fileType="pdf" /></li>
           <li><app-innovation-record-export [innovationId]="this.innovationId" fileType="csv" /></li>
         </ul>

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.html
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.html
@@ -156,6 +156,7 @@
       @if (ctx.user.isInnovator()) {
         <ul class="nhsuk-u-margin-bottom-7">
           <li><a href="javascript:void(0)" (click)="downloadInnovationRecordDocument()">Download all the questions (DOCX)</a> in your innovation record</li>
+          <li><a href="javascript:void(0)" (click)="downloadInnovationRecordExcel()">Download the Innovation Record as Excel (XLSX)</a></li>
           <li><app-innovation-record-export [innovationId]="this.innovationId" fileType="pdf" /></li>
           <li><app-innovation-record-export [innovationId]="this.innovationId" fileType="csv" /></li>
         </ul>

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.ts
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.ts
@@ -138,4 +138,27 @@ export class PageInnovationRecordComponent extends CoreComponent implements OnIn
       }
     });
   }
+
+  downloadInnovationRecordExcel(): void {
+    this.ctx.innovation.getAllSectionsInfo$(this.innovationId).subscribe({
+      next: (payload: any) => {
+        this.innovationsService.getInnovationRecordExcelExport(payload).subscribe({
+          next: (blob: Blob) => {
+            const url = window.URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `${this.innovation.name}-Innovation-Record.xlsx`;
+            link.click();
+            window.URL.revokeObjectURL(url);
+          },
+          error: () => {
+            this.setAlertError('Unable to download the Excel export. Please try again.');
+          }
+        });
+      },
+      error: () => {
+        this.setAlertError('Unable to retrieve sections data for export.');
+      }
+    });
+  }
 }

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.ts
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.ts
@@ -141,8 +141,17 @@ export class PageInnovationRecordComponent extends CoreComponent implements OnIn
 
   downloadInnovationRecordExcel(): void {
     this.ctx.innovation.getAllSectionsInfo$(this.innovationId).subscribe({
-      next: (payload: any) => {
-        this.innovationsService.getInnovationRecordExcelExport(payload).subscribe({
+      next: (payload: any[]) => {
+        // Transform the InnovationAllSectionsInfoDTO array into an InnovationRecordDocumentType object
+        // The backend ExcelExportService expects a dictionary keyed by section ID.
+        const exportPayload = payload.reduce((acc, curr) => {
+          if (curr?.section?.section && curr?.data) {
+            acc[curr.section.section] = curr.data;
+          }
+          return acc;
+        }, {} as Record<string, any>);
+
+        this.innovationsService.getInnovationRecordExcelExport(exportPayload).subscribe({
           next: (blob: Blob) => {
             const url = window.URL.createObjectURL(blob);
             const link = document.createElement('a');

--- a/src/modules/shared/pages/innovation/record/innovation-record.component.ts
+++ b/src/modules/shared/pages/innovation/record/innovation-record.component.ts
@@ -144,12 +144,15 @@ export class PageInnovationRecordComponent extends CoreComponent implements OnIn
       next: (payload: any[]) => {
         // Transform the InnovationAllSectionsInfoDTO array into an InnovationRecordDocumentType object
         // The backend ExcelExportService expects a dictionary keyed by section ID.
-        const exportPayload = payload.reduce((acc, curr) => {
-          if (curr?.section?.section && curr?.data) {
-            acc[curr.section.section] = curr.data;
-          }
-          return acc;
-        }, {} as Record<string, any>);
+        const exportPayload = payload.reduce(
+          (acc, curr) => {
+            if (curr?.section?.section && curr?.data) {
+              acc[curr.section.section] = curr.data;
+            }
+            return acc;
+          },
+          {} as Record<string, any>
+        );
 
         this.innovationsService.getInnovationRecordExcelExport(exportPayload).subscribe({
           next: (blob: Blob) => {

--- a/src/modules/shared/services/innovations.service.ts
+++ b/src/modules/shared/services/innovations.service.ts
@@ -979,25 +979,77 @@ export class InnovationsService extends CoreService {
       })
       .pipe(
         take(1),
-        map(response => {
-          // The response body is Base64 encoded
-          const base64Content = response.body || '';
-
-          // Convert Base64 to binary
-          const binaryString = atob(base64Content);
-          const bytes = new Uint8Array(binaryString.length);
-
-          for (let i = 0; i < binaryString.length; i++) {
-            bytes[i] = binaryString.charCodeAt(i);
-          }
-
-          // Create blob with correct MIME type
-          const blob = new Blob([bytes], {
-            type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-          });
-
-          return blob;
-        })
+        map(response =>
+          this.base64ToBlob(
+            response.body || '',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+          )
+        )
       );
+  }
+
+  /**
+   * Generates an empty Excel template for the Innovation Record.
+   */
+  getInnovationRecordExcelTemplate(): Observable<Blob> {
+    const url = new UrlModel(this.API_INNOVATIONS_URL).addPath('v1/innovation-record/xlsx');
+
+    return this.http
+      .get(url.buildUrl(), {
+        responseType: 'text',
+        observe: 'response'
+      })
+      .pipe(
+        take(1),
+        map(response =>
+          this.base64ToBlob(
+            response.body || '',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+          )
+        )
+      );
+  }
+
+  /**
+   * Generates a pre-filled Excel file based on the provided Innovation Record payload.
+   */
+  getInnovationRecordExcelExport(payload: any): Observable<Blob> {
+    const url = new UrlModel(this.API_INNOVATIONS_URL).addPath('v1/innovation-record/xlsx');
+
+    return this.http
+      .post(url.buildUrl(), payload, {
+        responseType: 'text',
+        observe: 'response'
+      })
+      .pipe(
+        take(1),
+        map(response =>
+          this.base64ToBlob(
+            response.body || '',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+          )
+        )
+      );
+  }
+
+  /**
+   * Creates a new Innovation Record (DRAFT) by uploading a filled Excel file.
+   * @param base64File Base64 encoded string of the Excel file.
+   */
+  createInnovationFromExcel(base64File: string): Observable<{ id: string }> {
+    const url = new UrlModel(this.API_INNOVATIONS_URL).addPath('v1/innovations/xlsx');
+
+    return this.http.post<{ id: string }>(url.buildUrl(), { file: base64File }).pipe(take(1));
+  }
+
+  private base64ToBlob(base64Content: string, type: string): Blob {
+    const binaryString = atob(base64Content);
+    const bytes = new Uint8Array(binaryString.length);
+
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+
+    return new Blob([bytes], { type });
   }
 }

--- a/src/modules/shared/services/innovations.service.ts
+++ b/src/modules/shared/services/innovations.service.ts
@@ -1037,9 +1037,9 @@ export class InnovationsService extends CoreService {
    * @param base64File Base64 encoded string of the Excel file.
    */
   createInnovationFromExcel(base64File: string): Observable<{ id: string }> {
-    const url = new UrlModel(this.API_INNOVATIONS_URL).addPath('v1/innovations/xlsx');
+    const url = new UrlModel(this.API_INNOVATIONS_URL).addPath('v1/innovations/import');
 
-    return this.http.post<{ id: string }>(url.buildUrl(), { file: base64File }).pipe(take(1));
+    return this.http.post<{ id: string }>(url.buildUrl(), { format: 'excel', file: base64File }).pipe(take(1));
   }
 
   private base64ToBlob(base64Content: string, type: string): Blob {

--- a/src/modules/shared/services/innovations.service.ts
+++ b/src/modules/shared/services/innovations.service.ts
@@ -1002,10 +1002,7 @@ export class InnovationsService extends CoreService {
       .pipe(
         take(1),
         map(response =>
-          this.base64ToBlob(
-            response.body || '',
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-          )
+          this.base64ToBlob(response.body || '', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
         )
       );
   }
@@ -1024,10 +1021,7 @@ export class InnovationsService extends CoreService {
       .pipe(
         take(1),
         map(response =>
-          this.base64ToBlob(
-            response.body || '',
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-          )
+          this.base64ToBlob(response.body || '', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
         )
       );
   }

--- a/src/modules/stores/ctx/schema/schema.store.ts
+++ b/src/modules/stores/ctx/schema/schema.store.ts
@@ -223,6 +223,10 @@ export class SchemaContextStore {
     }, []);
   }
 
+  getNumberedTranslatedSection(id: string): string {
+    return this.getIrSchemaNumberedSubSectionsList().find(s => s.value === id)?.label ?? id;
+  }
+
   getIrSchemaTranslationsMap(): IrSchemaTranslatorMapType {
     return irSchemaTranslationsMap(this.irSchemaInfo().schema);
   }


### PR DESCRIPTION
Introduces a new flow on `innovation-new` to allow to download a xlsx excel file version of the IR, and later import said file and create a new innovation from it.
