### PR TITLE
fix: correct CSRF token validation logic

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -75,8 +75,8 @@ export function app(): express.Express {
   // CSRF protection.
   server.use((req, res, next) => {
     if (!(req.method === 'OPTIONS' || req.method === 'GET' || req.method === 'HEAD')) {
-      if (!req.cookies['XSRF-TOKEN'] && req.cookies['XSRF-TOKEN'] !== (req.session as any).xsrfToken) {
-        res.send(403);
+      if (!req.cookies['XSRF-TOKEN'] || req.cookies['XSRF-TOKEN'] !== (req.session as any).xsrfToken) {
+        return res.status(403).send('Forbidden');
       }
     }
     next();


### PR DESCRIPTION
## Summary

The CSRF token validation middleware in `server.ts` has a logic error that completely bypasses CSRF protection.

### The Bug

The original condition used `&&` (AND) instead of `||` (OR):

```typescript
if (!req.cookies['XSRF-TOKEN'] && req.cookies['XSRF-TOKEN'] !== (req.session as any).xsrfToken) {
  res.send(403);
}
```

This means:
- If the cookie is **missing** (`!cookie` is true) → rejects ✓
- If the cookie is **present but wrong** (`!cookie` is false) → condition short-circuits to false → **accepts** ✗

An attacker can simply set a fake `XSRF-TOKEN` cookie and bypass CSRF entirely on all POST/PATCH/DELETE/PUT requests.

Additionally, `next()` was called unconditionally, meaning route handlers would still execute even after sending a 403 response.

### The Fix

```typescript
if (!req.cookies['XSRF-TOKEN'] || req.cookies['XSRF-TOKEN'] !== (req.session as any).xsrfToken) {
  return res.status(403).send('Forbidden');
}
```

- Changed `&&` to `||` — now rejects if cookie is missing **or** doesn't match
- Added `return` to prevent `next()` from running after rejection
- Changed `res.send(403)` to `res.status(403).send('Forbidden')` for proper HTTP response

### Impact

This is a **critical security vulnerability**. Without this fix, all state-changing requests (creating innovations, managing users, submitting assessments, etc.) are unprotected against CSRF attacks.