### PR TITLE
fix: correct CSRF token validation logic

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -75,8 +75,8 @@ export function app(): express.Express {
   // CSRF protection.
   server.use((req, res, next) => {
     if (!(req.method === 'OPTIONS' || req.method === 'GET' || req.method === 'HEAD')) {
-      if (!req.cookies['XSRF-TOKEN'] && req.cookies['XSRF-TOKEN'] !== (req.session as any).xsrfToken) {
-        res.send(403);
+      if (!req.cookies['XSRF-TOKEN'] || req.cookies['XSRF-TOKEN'] !== (req.session as any).xsrfToken) {
+        return res.status(403).send('Forbidden');
       }
     }
     next();

--- a/server.ts
+++ b/server.ts
@@ -76,7 +76,8 @@ export function app(): express.Express {
   server.use((req, res, next) => {
     if (!(req.method === 'OPTIONS' || req.method === 'GET' || req.method === 'HEAD')) {
       if (!req.cookies['XSRF-TOKEN'] || req.cookies['XSRF-TOKEN'] !== (req.session as any).xsrfToken) {
-        return res.status(403).send('Forbidden');
+        res.status(403).send('Forbidden');
+        return;
       }
     }
     next();


### PR DESCRIPTION
The CSRF check used && instead of ||, which meant any cookie value (including attacker-controlled ones) bypassed the token comparison. Also added return to prevent next() from executing after sending 403.